### PR TITLE
Remove max-count option for Mountain Lion

### DIFF
--- a/Finder/PatternFinder.php
+++ b/Finder/PatternFinder.php
@@ -140,7 +140,7 @@ class PatternFinder
             $cmd .= ' --directories=skip';
         }
 
-        $cmd .= ' --devices=skip --files-with-matches --with-filename --max-count=1 --color=never --include='.$this->filePattern;
+        $cmd .= ' --devices=skip --files-with-matches --with-filename --color=never --include='.$this->filePattern;
         $cmd .= ' '.escapeshellarg($this->pattern);
 
         foreach ($dirs as $dir) {


### PR DESCRIPTION
Hi,

I've just discovered a really really strange bug after upgrading my MBP to Mountain Lion. It seems that "grep" version has change since Lion and especially the "max-count" option. While in Lion, "max-count=NUM" was meaning "stop reading a file after NUM match(es) in the file", in Mountain Lion, it seems to mean "stop reading input after NUM file(s) matching criterias". 
And since DiExtraBundle is using grep to find all files (in JMS\DiExtraBundle\Finder\PatternFinder) that need to be processed, it stops after the first file.

Examples on Mountain Lion :

=> max-count=1
`MacBook-Pro-de-Remi:publicWebsite remi$ /usr/bin/grep --fixed-strings --directories=recurse --devices=skip --files-with-matches --with-filename --max-count=1 --color=never --include=*.php 'JMS\DiExtraBundle\Annotation' '/Users/remi/dev/sa/publicWebsite/vendor/bundles/Kbrw/SA/Bundles/ResponseBundle'
/Users/remi/dev/sa/publicWebsite/vendor/bundles/Kbrw/SA/Bundles/ResponseBundle/Provider/ContentProvider.php`

=> max-count=5
`MacBook-Pro-de-Remi:publicWebsite remi$ /usr/bin/grep --fixed-strings --directories=recurse --devices=skip --files-with-matches --with-filename --max-count=5 --color=never --include=*.php 'JMS\DiExtraBundle\Annotation' '/Users/remi/dev/sa/publicWebsite/vendor/bundles/Kbrw/SA/Bundles/ResponseBundle'
/Users/remi/dev/sa/publicWebsite/vendor/bundles/Kbrw/SA/Bundles/ResponseBundle/Provider/ContentProvider.php
/Users/remi/dev/sa/publicWebsite/vendor/bundles/Kbrw/SA/Bundles/ResponseBundle/Provider/OfferProvider.php
/Users/remi/dev/sa/publicWebsite/vendor/bundles/Kbrw/SA/Bundles/ResponseBundle/Provider/OffersProvider.php
/Users/remi/dev/sa/publicWebsite/vendor/bundles/Kbrw/SA/Bundles/ResponseBundle/Provider/StoreProvider.php
/Users/remi/dev/sa/publicWebsite/vendor/bundles/Kbrw/SA/Bundles/ResponseBundle/Provider/StoresProvider.php`

=> without max-count
`MacBook-Pro-de-Remi:publicWebsite remi$ /usr/bin/grep --fixed-strings --directories=recurse --devices=skip --files-with-matches --with-filename --color=never --include=*.php 'JMS\DiExtraBundle\Annotation' '/Users/remi/dev/sa/publicWebsite/vendor/bundles/Kbrw/SA/Bundles/ResponseBundle'
/Users/remi/dev/sa/publicWebsite/vendor/bundles/Kbrw/SA/Bundles/ResponseBundle/Provider/ContentProvider.php
/Users/remi/dev/sa/publicWebsite/vendor/bundles/Kbrw/SA/Bundles/ResponseBundle/Provider/OfferProvider.php
/Users/remi/dev/sa/publicWebsite/vendor/bundles/Kbrw/SA/Bundles/ResponseBundle/Provider/OffersProvider.php
/Users/remi/dev/sa/publicWebsite/vendor/bundles/Kbrw/SA/Bundles/ResponseBundle/Provider/StoreProvider.php
/Users/remi/dev/sa/publicWebsite/vendor/bundles/Kbrw/SA/Bundles/ResponseBundle/Provider/StoresProvider.php
/Users/remi/dev/sa/publicWebsite/vendor/bundles/Kbrw/SA/Bundles/ResponseBundle/Provider/SurtaxedPhoneNumberProvider.php
/Users/remi/dev/sa/publicWebsite/vendor/bundles/Kbrw/SA/Bundles/ResponseBundle/Provider/TreeProvider.php`

After installing the gnu grep version from macport, everything is working as before but since --max-count is more a convenience than a requirement (the result is cached on production environment), I vote to remove this option so we won't have to bother with grep version.
