### PR TITLE
use include_once instead of require_once to handle non requireable Controller files

### DIFF
--- a/HttpKernel/ControllerInjectorsWarmer.php
+++ b/HttpKernel/ControllerInjectorsWarmer.php
@@ -49,7 +49,7 @@ class ControllerInjectorsWarmer implements CacheWarmerInterface
         }
 
         foreach (Finder::create()->name('*Controller.php')->in($dirs)->files() as $file) {
-            require_once $file->getRealPath();
+            @include_once $file->getRealPath();
         }
 
         // It is not so important if these controllers never can be reached with


### PR DESCRIPTION
this solves the biggest issues noted in #63, now i at least dont get a fatal error anymore.
