### PR TITLE
Invalid namespace identifiers within Cygwin environment

### DIFF
--- a/DependencyInjection/JMSDiExtraExtension.php
+++ b/DependencyInjection/JMSDiExtraExtension.php
@@ -70,6 +70,9 @@ class JMSDiExtraExtension extends Extension
 
         $enhancer = new Enhancer($ref = new \ReflectionClass('Doctrine\ORM\EntityManager'), array(), array(new RepositoryInjectionGenerator()));
         $uniqid = uniqid(); // We do have to use a non-static id to avoid problems with cache:clear.
+        if (strtoupper(PHP_OS)=='CYGWIN') {
+            $uniqid=preg_replace('/\./','_',$uniqid); // replace dot; cygwin always generates uniqid's with more_entropy
+        }
         $enhancer->setNamingStrategy(new DefaultNamingStrategy('EntityManager'.$uniqid));
         $enhancer->writeClass($file = $cacheDir.'/doctrine/EntityManager_'.$uniqid.'.php');
         $container->setParameter('jms_di_extra.doctrine_integration.entity_manager.file', $file);


### PR DESCRIPTION
Opposite to other OS/environments, Cygwin requires uniqeid() to be with more entropy and also defaults to it (see http://php.net/manual/en/function.uniqid.php, example 01).

Cygwin (php 5.3.16):

``````
<?php echo uniqid();
50ac952df064f0.57784423

<?php echo uniqid('',false);
PHP Warning:  uniqid(): You must use 'more entropy' under CYGWIN in - on line 1```
``````

So the uniqid() function will always generate a longer uniqid with a dot thus the injected namespace identifier is not valid anymore (no dot allowed) and therefore breaking the code.

i.e.
`namespace EntityManager50ac9577689c12.16592573_546a8d27f194334ee012bfe64f629947b07e4919\__CG__\Doctrine\ORM;`

This has to be fixed this in JMSDiExtraEntension.php (line 72). A possible solution is to query the OS and if it's Cygwin then replace the dot with an underscore.
