### PR TITLE
Fix issue #61 by adding a disable_grep flag.

### DIFF
--- a/Config/FastDirectoriesResource.php
+++ b/Config/FastDirectoriesResource.php
@@ -30,9 +30,9 @@ class FastDirectoriesResource implements ResourceInterface
     private $filePattern;
     private $files = array();
 
-    public function __construct(array $directories, $filePattern = null)
+    public function __construct(array $directories, $filePattern = null, $disableGrep = false)
     {
-        $this->finder = new PatternFinder('.*', '*.php');
+        $this->finder = new PatternFinder('.*', '*.php', $disableGrep);
         $this->finder->setRegexPattern(true);
 
         $this->directories = $directories;

--- a/Config/ServiceFilesResource.php
+++ b/Config/ServiceFilesResource.php
@@ -25,16 +25,18 @@ class ServiceFilesResource implements ResourceInterface
 {
     private $files;
     private $dirs;
+    private $disableGrep;
 
-    public function __construct(array $files, array $dirs)
+    public function __construct(array $files, array $dirs, $disableGrep)
     {
         $this->files = $files;
         $this->dirs = $dirs;
+        $this->disableGrep = $disableGrep;
     }
 
     public function isFresh($timestamp)
     {
-        $finder = new PatternFinder('JMS\DiExtraBundle\Annotation');
+        $finder = new PatternFinder('JMS\DiExtraBundle\Annotation', '*.php', $this->disableGrep);
         $files = $finder->findFiles($this->dirs);
 
         return !array_diff($files, $this->files) && !array_diff($this->files, $files);

--- a/DependencyInjection/Compiler/ResourceOptimizationPass.php
+++ b/DependencyInjection/Compiler/ResourceOptimizationPass.php
@@ -68,8 +68,10 @@ class ResourceOptimizationPass implements CompilerPassInterface
             $directories[$pattern] = $newResources;
         }
 
+        $disableGrep = $container->getParameter('jms_di_extra.disable_grep');
+
         foreach ($directories as $pattern => $pDirectories) {
-            $newResource = new FastDirectoriesResource($pDirectories, $pattern);
+            $newResource = new FastDirectoriesResource($pDirectories, $pattern, $disableGrep);
             $newResource->update();
             $resources[] = $newResource;
         }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -66,6 +66,7 @@ class Configuration implements ConfigurationInterface
                         ->end()
                     ->end()
                     ->scalarNode('cache_dir')->defaultValue('%kernel.cache_dir%/jms_diextra')->end()
+                    ->scalarNode('disable_grep')->defaultFalse()->end()
                     ->arrayNode('metadata')
                         ->addDefaultsIfNotSet()
                         ->children()

--- a/DependencyInjection/JMSDiExtraExtension.php
+++ b/DependencyInjection/JMSDiExtraExtension.php
@@ -51,6 +51,7 @@ class JMSDiExtraExtension extends Extension
         $container->setParameter('jms_di_extra.bundles', $config['locations']['bundles']);
         $container->setParameter('jms_di_extra.directories', $config['locations']['directories']);
         $container->setParameter('jms_di_extra.cache_dir', $config['cache_dir']);
+        $container->setParameter('jms_di_extra.disable_grep', $config['disable_grep']);
         $container->setParameter('jms_di_extra.doctrine_integration', $config['doctrine_integration']);
         if ($config['cache_warmer']['enabled']) {
             foreach ($config['cache_warmer']['controller_file_blacklist'] as $filename) {

--- a/Finder/PatternFinder.php
+++ b/Finder/PatternFinder.php
@@ -36,10 +36,10 @@ class PatternFinder
     private $recursive = true;
     private $regexPattern = false;
 
-    public function __construct($pattern, $filePattern = '*.php')
+    public function __construct($pattern, $filePattern = '*.php', $disableGrep = false, $forceMethodReload = false)
     {
-        if (null === self::$method) {
-            self::determineMethod();
+        if (null === self::$method || $forceMethodReload) {
+            self::determineMethod($disableGrep);
         }
 
         $this->pattern = $pattern;
@@ -185,13 +185,13 @@ class PatternFinder
         return array_keys(iterator_to_array($finder));
     }
 
-    private static function determineMethod()
+    private static function determineMethod($disableGrep)
     {
         $finder = new ExecutableFinder();
         $isWindows = 0 === stripos(PHP_OS, 'win');
         $execAvailable = function_exists('exec');
 
-        if (!$isWindows && $execAvailable && self::$grepPath = $finder->find('grep')) {
+        if (!$isWindows && $execAvailable && !$disableGrep && self::$grepPath = $finder->find('grep')) {
             self::$method = self::METHOD_GREP;
         } else if ($isWindows && $execAvailable) {
             self::$method = self::METHOD_FINDSTR;

--- a/Tests/DependencyInjection/Compiler/ResourceOptimizationPassTest.php
+++ b/Tests/DependencyInjection/Compiler/ResourceOptimizationPassTest.php
@@ -27,6 +27,7 @@ class ResourceOptimizationPassTest extends \PHPUnit_Framework_TestCase
     public function testProcess()
     {
         $container = new ContainerBuilder();
+        $container->setParameter('jms_di_extra.disable_grep', false);
         $container->addResource(new DirectoryResource(__DIR__.'/Fixtures/a'));
         $container->addResource(new DirectoryResource(__DIR__.'/Fixtures/a/b'));
         $container->addResource(new DirectoryResource(__DIR__.'/Fixtures/c'));

--- a/Tests/Finder/GrepPatternFinderTest.php
+++ b/Tests/Finder/GrepPatternFinderTest.php
@@ -22,16 +22,41 @@ use JMS\DiExtraBundle\Finder\PatternFinder;
 
 class GrepPatternFinderTest extends AbstractPatternFinderTest
 {
+    protected $disableGrep = false;
+    protected $forceMethodReload = false;
+
     protected function getFinder()
     {
-        $finder = new PatternFinder('JMS\DiExtraBundle\Annotation');
+        $finder = new PatternFinder(
+            'JMS\DiExtraBundle\Annotation',
+            '*.php',
+            $this->disableGrep,
+            $this->forceMethodReload
+        );
 
-        $ref = new \ReflectionProperty($finder, 'grepPath');
-        $ref->setAccessible(true);
-        if (null === $v = $ref->getValue($finder)) {
-            $this->markTestSkipped('grep is not available on your system.');
+        if (!$this->disableGrep) {
+            $ref = new \ReflectionProperty($finder, 'grepPath');
+            $ref->setAccessible(true);
+            if (null === $v = $ref->getValue($finder)) {
+                $this->markTestSkipped('grep is not available on your system.');
+            }
         }
 
         return $finder;
+    }
+
+    public function testFinderMethodIsNotGrepIfDisableGrepParameterIsSetToTrue()
+    {
+        // Change the flag to disable grep
+        $this->disableGrep = true;
+        $this->forceMethodReload = true;
+
+        // Get the finder and a reflection object on its method property
+        $finder = $this->getFinder();
+        $ref = new \ReflectionProperty($finder, 'method');
+        $ref->setAccessible(true);
+
+        // Ensure the method is not grep
+        $this->assertNotEquals(PatternFinder::METHOD_GREP, $ref->getValue($finder));
     }
 }


### PR DESCRIPTION
This pull request solve the issue #61 when using this bundle on Solaris (or any OS on which the grep version is quite old) by allowing to disable the usage of grep thanks to a simple configuration flag.

Tests are running well on my Debian install:

```
....SS..................

Time: 5 seconds, Memory: 57.25Mb

OK, but incomplete or skipped tests!
Tests: 24, Assertions: 54, Skipped: 2.
```

I guess the two skip tests are due to the tests of findstr (available on Windows only).

Otherwise, I think it would be great if this fix could be backported to the 1.1.\* version of the bundle (for Symfony 2.1 usage, which is still maintained for at least a month). @schmittjoh What do you think ?
