### PR TITLE
Fixed the LazyServiceMapPass to allow several tags per service

### DIFF
--- a/DependencyInjection/Compiler/LazyServiceMapPass.php
+++ b/DependencyInjection/Compiler/LazyServiceMapPass.php
@@ -45,12 +45,14 @@ class LazyServiceMapPass implements CompilerPassInterface, \Serializable
         }
 
         $serviceMap = array();
-        foreach ($container->findTaggedServiceIds($this->tagName) as $id => $attrs) {
-            if ( ! isset($attrs[0][$this->keyAttributeName])) {
-                throw new \RuntimeException(sprintf('The attribute "%s" must be set for service "%s" and tag "%s".', $this->keyAttributeName, $id, $this->tagName));
+        foreach ($container->findTaggedServiceIds($this->tagName) as $id => $tags) {
+            foreach ($tags as $tag) {
+                if ( ! isset($tag[$this->keyAttributeName])) {
+                    throw new \RuntimeException(sprintf('The attribute "%s" must be set for service "%s" and tag "%s".', $this->keyAttributeName, $id, $this->tagName));
+                }
+    
+                $serviceMap[$tag[$this->keyAttributeName]] = $id;
             }
-
-            $serviceMap[$attrs[0][$this->keyAttributeName]] = $id;
         }
 
         $def = new Definition('JMS\DiExtraBundle\DependencyInjection\Collection\LazyServiceMap');

--- a/Tests/DependencyInjection/Compiler/LazyServiceMapPassTest.php
+++ b/Tests/DependencyInjection/Compiler/LazyServiceMapPassTest.php
@@ -19,7 +19,7 @@ class LazyServiceMapPassTest extends \PHPUnit_Framework_TestCase
             $called = true;
 
             $self->assertEquals(new Reference('service_container'), $def->getArgument(0));
-            $self->assertEquals(array('json' => 'foo', 'xml' => 'bar'), $def->getArgument(1));
+            $self->assertEquals(array('json' => 'foo', 'xml' => 'bar', 'atom' => 'bar'), $def->getArgument(1));
         });
 
         $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerBuilder')
@@ -30,7 +30,7 @@ class LazyServiceMapPassTest extends \PHPUnit_Framework_TestCase
         $container->expects($this->once())
             ->method('findTaggedServiceIds')
             ->with('tag')
-            ->will($this->returnValue(array('foo' => array(array('key' => 'json')), 'bar' => array(array('key' => 'xml')))));
+            ->will($this->returnValue(array('foo' => array(array('key' => 'json')), 'bar' => array(array('key' => 'xml'), array('key' => 'atom')))));
 
         $pass->process($container);
         $this->assertTrue($called);


### PR DESCRIPTION
Without the change, only the first tag is taken into account. In the unit tests, this means that the `atom` format was not registered.
