### PR TITLE
EntityManager class name.

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -97,7 +97,21 @@ class Configuration implements ConfigurationInterface
                             ->end()
                         ->end()
                     ->end()
-                    ->booleanNode('doctrine_integration')
+                    ->arrayNode('doctrine')
+                        ->addDefaultsIfNotSet()
+                        ->children()
+                            ->scalarNode('entity_manager_class')->defaultValue('Doctrine\ORM\EntityManager')
+                            ->validate()
+                                ->always(function($v) {
+                                    if(!is_subclass_of($v, 'Doctrine\ORM\EntityManager')) {
+                                        throw new \Exception('The entity manager class must extends Doctrine\ORM\EntityManager.');
+                                    }
+
+                                    return $v;
+                                })
+                            ->end()
+                        ->end()
+                        ->booleanNode('doctrine_integration')
                         ->validate()
                             ->always(function($v) {
                                 if ($v && !class_exists('Doctrine\ORM\EntityManager')) {
@@ -108,6 +122,7 @@ class Configuration implements ConfigurationInterface
                             })
                         ->end()
                         ->defaultValue(class_exists('Doctrine\ORM\EntityManager'))->end()
+                    ->end()
                 ->end()
             ->end();
 

--- a/DependencyInjection/JMSDiExtraExtension.php
+++ b/DependencyInjection/JMSDiExtraExtension.php
@@ -43,7 +43,6 @@ class JMSDiExtraExtension extends Extension
     public function load(array $configs, ContainerBuilder $container)
     {
         $config = $this->mergeConfigs($configs);
-
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.xml');
 
@@ -52,7 +51,7 @@ class JMSDiExtraExtension extends Extension
         $container->setParameter('jms_di_extra.directories', $config['locations']['directories']);
         $container->setParameter('jms_di_extra.cache_dir', $config['cache_dir']);
         $container->setParameter('jms_di_extra.disable_grep', $config['disable_grep']);
-        $container->setParameter('jms_di_extra.doctrine_integration', $config['doctrine_integration']);
+        $container->setParameter('jms_di_extra.doctrine_integration', $config['doctrine']['doctrine_integration']);
         if ($config['cache_warmer']['enabled']) {
             foreach ($config['cache_warmer']['controller_file_blacklist'] as $filename) {
                 $this->blackListControllerFile($filename);
@@ -65,7 +64,7 @@ class JMSDiExtraExtension extends Extension
         $this->configureMetadata($config['metadata'], $container, $config['cache_dir'].'/metadata');
         $this->configureAutomaticControllerInjections($config, $container);
 
-        if ($config['doctrine_integration']) {
+        if ($config['doctrine']['doctrine_integration']) {
             $this->generateEntityManagerProxyClass($config, $container);
         }
 
@@ -88,8 +87,7 @@ class JMSDiExtraExtension extends Extension
                 throw new \RuntimeException(sprintf('Could not create cache directory "%s".', $cacheDir.'/doctrine'));
             }
         }
-
-        $enhancer = new Enhancer($ref = new \ReflectionClass($container['doctrine.orm.entity_manager.class']), array(), array(new RepositoryInjectionGenerator()));
+        $enhancer = new Enhancer($ref = new \ReflectionClass($config['doctrine']['entity_manager_class']), array(), array(new RepositoryInjectionGenerator()));
         $uniqid = uniqid(); // We do have to use a non-static id to avoid problems with cache:clear.
         if (strtoupper(PHP_OS)=='CYGWIN') {
             $uniqid=preg_replace('/\./','_',$uniqid); // replace dot; cygwin always generates uniqid's with more_entropy


### PR DESCRIPTION
Hello,

I'm trying to extend the EntityManager in order to add and override some methods but the EntityManager class name is hardcoded when proxies are generated. If you get it from the container you can override the doctrine.orm.entity_manager.class parameter.
