### PR TITLE
Added work-around to be compatible with cache:clear command in Symfony 2.3.x

### DIFF
--- a/HttpKernel/ControllerInjectorsWarmer.php
+++ b/HttpKernel/ControllerInjectorsWarmer.php
@@ -32,6 +32,10 @@ class ControllerInjectorsWarmer implements CacheWarmerInterface
             return;
         }
 
+        if (basename($cacheDir) === substr($this->kernel->getEnvironment(), 0, -1).'_') {
+            return;
+        }
+
         $classes = $this->findControllerClasses();
         foreach ($classes as $class) {
             $this->controllerResolver->createInjector($class);


### PR DESCRIPTION
Temporary cache directory naming was changed in symfony/symfony here:

https://github.com/symfony/symfony/issues/7360

Also discussed here https://github.com/schmittjoh/JMSDiExtraBundle/issues/96
