### PR TITLE
allow single @inject annotations on methods

### DIFF
--- a/Annotation/Inject.php
+++ b/Annotation/Inject.php
@@ -20,7 +20,7 @@ namespace JMS\DiExtraBundle\Annotation;
 
 /**
  * @Annotation
- * @Target({"PROPERTY", "ANNOTATION"})
+ * @Target({"PROPERTY", "ANNOTATION", "METHOD"})
  */
 final class Inject extends Reference
 {

--- a/Metadata/Driver/AnnotationDriver.php
+++ b/Metadata/Driver/AnnotationDriver.php
@@ -154,6 +154,18 @@ class AnnotationDriver implements DriverInterface
                         'function' => $annot->function,
                         'method' => $name,
                     );
+                } else if ($annot instanceof Inject) {
+                    if ($method->getNumberOfParameters() > 1) {
+                        throw new \RuntimeException(sprintf('The method "%s::%s" has more than 1 parameter, use @InjectParam instead of @Inject.', $className, $name));
+                    }
+                    $params = $method->getParameters();
+                    $params = array($this->convertReferenceValue($params[0]->getName(), $annot));
+
+                    if ('__construct' === $name) {
+                        $metadata->arguments = $params;
+                    } else {
+                        $metadata->methodCalls[] = array($name, $params);
+                    }
                 } else if ($annot instanceof InjectParams) {
                     $params = array();
                     foreach ($method->getParameters() as $param) {


### PR DESCRIPTION
I'm converting my project with >1000 annotated services and even more annotated methods to this bundle. 
most of our methods are annotated with single @inject annotation. 
for convenience i've implemented the option to use a single annotation, if the method in question only expects one parameter.

so this is valid now:
```
/**
 * @Inject('service_name')
 */
public function setService(SomeService $service) {
}
```