### PR TITLE
Added `symfony/expression-language` to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
         "symfony/browser-kit": "*",
         "symfony/security-bundle": "*",
         "symfony/twig-bundle": "*",
+        "symfony/expression-language": "*",
         "sensio/framework-extra-bundle": "*",
         "jms/security-extra-bundle": "1.*",
         "doctrine/doctrine-bundle": "*",


### PR DESCRIPTION
Tests are failing:

```
Fatal error: Class 'Symfony\Component\ExpressionLanguage\ExpressionLanguage' not found in /Volumes/www/test/JMSDiExtraBundle/vendor/symfony/security/Symfony/Component/Security/Core/Authorization/ExpressionLanguage.php on line 22
```

Added `symfony/expression-language` to composer.json to fix it.
