### PR TITLE
Add lazy attribute to service annotation

### DIFF
--- a/Annotation/Service.php
+++ b/Annotation/Service.php
@@ -40,4 +40,7 @@ final class Service
 
     /** @var boolean */
     public $abstract;
+
+    /** @var  boolean */
+    public $lazy;
 }

--- a/Metadata/ClassMetadata.php
+++ b/Metadata/ClassMetadata.php
@@ -27,6 +27,7 @@ class ClassMetadata extends BaseClassMetadata
     public $scope;
     public $public;
     public $abstract;
+    public $lazy;
     public $tags = array();
     public $arguments;
     public $methodCalls = array();
@@ -42,6 +43,7 @@ class ClassMetadata extends BaseClassMetadata
             $this->scope,
             $this->public,
             $this->abstract,
+            $this->lazy,
             $this->tags,
             $this->arguments,
             $this->methodCalls,
@@ -60,6 +62,7 @@ class ClassMetadata extends BaseClassMetadata
             $this->scope,
             $this->public,
             $this->abstract,
+            $this->lazy,
             $this->tags,
             $this->arguments,
             $this->methodCalls,

--- a/Metadata/Driver/AnnotationDriver.php
+++ b/Metadata/Driver/AnnotationDriver.php
@@ -78,6 +78,7 @@ class AnnotationDriver implements DriverInterface
                 $metadata->public = $annot->public;
                 $metadata->scope = $annot->scope;
                 $metadata->abstract = $annot->abstract;
+                $metadata->lazy = $annot->lazy;
             } else if ($annot instanceof Tag) {
                 $metadata->tags[$annot->name][] = $annot->attributes;
             } else if ($annot instanceof Validator) {

--- a/Metadata/MetadataConverter.php
+++ b/Metadata/MetadataConverter.php
@@ -59,6 +59,9 @@ class MetadataConverter
             if (null !== $classMetadata->arguments) {
                 $definition->setArguments($classMetadata->arguments);
             }
+            if (null !== $classMetadata->lazy) {
+                $definition->setLazy($classMetadata->lazy);
+            }
 
             $definition->setMethodCalls($classMetadata->methodCalls);
             $definition->setTags($classMetadata->tags);


### PR DESCRIPTION
This PR adds the possiblity to set the `lazy` attribute for `@Service` annotations (see http://symfony.com/doc/current/components/dependency_injection/lazy_services.html for more information)