### PR TITLE
Fix namespace parsing regex to allow both allowed forms

### DIFF
--- a/DependencyInjection/Compiler/AnnotationConfigurationPass.php
+++ b/DependencyInjection/Compiler/AnnotationConfigurationPass.php
@@ -106,10 +106,10 @@ class AnnotationConfigurationPass implements CompilerPassInterface
     {
         $src = file_get_contents($filename);
 
-        if (!preg_match('/\bnamespace\s+([^;]+);/s', $src, $match)) {
+        if (!preg_match('/\bnamespace\s+([^;|^{]+)[;|{]/s', $src, $match)) {
             throw new RuntimeException(sprintf('Namespace could not be determined for file "%s".', $filename));
         }
-        $namespace = $match[1];
+        $namespace = trim($match[1]);
 
         if (!preg_match('/\bclass\s+([^\s]+)\s+(?:extends|implements|{)/s', $src, $match)) {
             throw new RuntimeException(sprintf('Could not extract class name from file "%s".', $filename));

--- a/DependencyInjection/Compiler/AnnotationConfigurationPass.php
+++ b/DependencyInjection/Compiler/AnnotationConfigurationPass.php
@@ -106,10 +106,10 @@ class AnnotationConfigurationPass implements CompilerPassInterface
     {
         $src = file_get_contents($filename);
 
-        if (!preg_match('/\bnamespace\s+([^;\{]+)(;|\{)/s', $src, $match)) {
+        if (!preg_match('/\bnamespace\s+([^;\{\s]+)\s*?[;\{]/s', $src, $match)) {
             throw new RuntimeException(sprintf('Namespace could not be determined for file "%s".', $filename));
         }
-        $namespace = trim($match[1]);
+        $namespace = $match[1];
 
         if (!preg_match('/\bclass\s+([^\s]+)\s+(?:extends|implements|{)/s', $src, $match)) {
             throw new RuntimeException(sprintf('Could not extract class name from file "%s".', $filename));

--- a/DependencyInjection/Compiler/AnnotationConfigurationPass.php
+++ b/DependencyInjection/Compiler/AnnotationConfigurationPass.php
@@ -106,7 +106,7 @@ class AnnotationConfigurationPass implements CompilerPassInterface
     {
         $src = file_get_contents($filename);
 
-        if (!preg_match('/\bnamespace\s+([^;|^{]+)[;|{]/s', $src, $match)) {
+        if (!preg_match('/\bnamespace\s+([^;\{]+)(;|\{)/s', $src, $match)) {
             throw new RuntimeException(sprintf('Namespace could not be determined for file "%s".', $filename));
         }
         $namespace = trim($match[1]);

--- a/Tests/Finder/AbstractPatternFinderTest.php
+++ b/Tests/Finder/AbstractPatternFinderTest.php
@@ -26,6 +26,7 @@ abstract class AbstractPatternFinderTest extends \PHPUnit_Framework_TestCase
 
         $expectedFiles = array(
             realpath(__DIR__.'/../Fixture/NonEmptyDirectory/Service1.php'),
+            realpath(__DIR__.'/../Fixture/NonEmptyDirectory/Service4.php'),
             realpath(__DIR__.'/../Fixture/NonEmptyDirectory/SubDir1/Service2.php'),
             realpath(__DIR__.'/../Fixture/NonEmptyDirectory/SubDir2/Service3.php'),
         );

--- a/Tests/Fixture/NonEmptyDirectory/Service2.php
+++ b/Tests/Fixture/NonEmptyDirectory/Service2.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * Copyright 2011 Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace JMS\DiExtraBundle\Tests\Fixture\NonEmptyDirectory {
+
+    use JMS\DiExtraBundle\Annotation as DI;
+
+    /** @DI\Service */
+    class Service2
+    {
+    }
+}

--- a/Tests/Fixture/NonEmptyDirectory/Service4.php
+++ b/Tests/Fixture/NonEmptyDirectory/Service4.php
@@ -21,7 +21,7 @@ namespace JMS\DiExtraBundle\Tests\Fixture\NonEmptyDirectory {
     use JMS\DiExtraBundle\Annotation as DI;
 
     /** @DI\Service */
-    class Service2
+    class Service4
     {
     }
 }


### PR DESCRIPTION
Allow namespace form of "namespace My\Name\Space {" in addition to "namespace My\Name\Space;"