### PR TITLE
LazyServiceMap > getIterator > Fixed notice

### DIFF
--- a/DependencyInjection/Collection/LazyServiceMap.php
+++ b/DependencyInjection/Collection/LazyServiceMap.php
@@ -45,9 +45,9 @@ class LazyServiceMap extends Map
 
     public function getIterator()
     {
-        foreach ($this->serviceIds as $k => $id) {
-            $this->set($k, $this->container->get($this->serviceIds[$id]));
-            unset($this->serviceIds[$k]);
+        foreach ($this->serviceIds as $key => $id) {
+            $this->set($key, $this->container->get($this->serviceIds[$key]));
+            unset($this->serviceIds[$key]);
         }
 
         return parent::getIterator();

--- a/DependencyInjection/Collection/LazyServiceMap.php
+++ b/DependencyInjection/Collection/LazyServiceMap.php
@@ -46,7 +46,7 @@ class LazyServiceMap extends Map
     public function getIterator()
     {
         foreach ($this->serviceIds as $key => $id) {
-            $this->set($key, $this->container->get($this->serviceIds[$key]));
+            $this->set($key, $this->container->get($id));
             unset($this->serviceIds[$key]);
         }
 

--- a/Tests/DependencyInjection/Collection/LazyServiceMapTest.php
+++ b/Tests/DependencyInjection/Collection/LazyServiceMapTest.php
@@ -3,17 +3,26 @@
 namespace JMS\DiExtraBundle\Tests\DependencyInjection\Collection;
 
 use JMS\DiExtraBundle\DependencyInjection\Collection\LazyServiceMap;
+use PHPUnit_Framework_MockObject_MockObject;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class LazyServiceMapTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @var LazyServiceMap
+     */
     private $map;
+
+    /**
+     * @var PHPUnit_Framework_MockObject_MockObject|ContainerInterface
+     */
     private $container;
 
     public function testGet()
     {
         $this->container->expects($this->once())
             ->method('get')
-            ->with('bar')
+            ->with('bar_service')
             ->will($this->returnValue($a = new \stdClass));
 
         $this->assertSame($a, $this->map->get('foo')->get());
@@ -24,7 +33,7 @@ class LazyServiceMapTest extends \PHPUnit_Framework_TestCase
     {
         $this->container->expects($this->once())
             ->method('get')
-            ->with('bar')
+            ->with('bar_service')
             ->will($this->returnValue($a = new \stdClass));
 
         $this->assertSame($a, $this->map->remove('foo'));
@@ -32,13 +41,33 @@ class LazyServiceMapTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($this->map->containsKey('foo'));
     }
 
+    public function testIterator()
+    {
+        $this->container->expects($this->at(0))
+            ->method('get')
+            ->with('bar_service')
+            ->will($this->returnValue($a = new \stdClass));
+
+        $this->container->expects($this->at(1))
+            ->method('get')
+            ->with('baz_service')
+            ->will($this->returnValue($b = new \stdClass));
+
+        $iterator = $this->map->getIterator();
+
+        $this->assertSame($a, $iterator->current());
+
+        $iterator->next();
+        $this->assertSame($b, $iterator->current());
+    }
+
     protected function setUp()
     {
         $this->container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
 
         $this->map = new LazyServiceMap($this->container, array(
-            'foo' => 'bar',
-            'bar' => 'baz',
+            'foo' => 'bar_service',
+            'bar' => 'baz_service',
         ));
     }
 }


### PR DESCRIPTION
I have a LazyServiceMap that consist of the following serviceIds:
```php
array(
  "popular_events_this_week" => "swapboard_bundle.slide.type.popular_events_this_week"
  "text" => "swapboard_bundle.slide.type.text"
  "today_phone_calls" => "swapboard_bundle.slide.type.today_phone_calls"
  "today_statistics" => "swapboard_bundle.slide.type.today_statistics"
  "week_statistics" => "swapboard_bundle.slide.type.week_statistics"
)
```

When calling
```php
$weekStatistics = $lazyServiceMap->get('week_statistics')->orElse(null);
```
it returns the right service.

But when foreach-ing over the map (using the Iterator) it throws a notice:
```php
foreach($lazyServiceMap as $name => $service) {
    
}
```

```
Notice: Undefined index: swapboard_bundle.slide.type.popular_events_this_week
```
![screen shot 2015-07-02 at 12 46 48](https://cloud.githubusercontent.com/assets/104180/8475469/71863d2e-20b8-11e5-929a-7152d64c5869.png)


It's because it's trying to get the service with the wrong key. This PR fixes it.