### PR TITLE
"Lazy" property in Service annotation: Define service as lazy

### DIFF
--- a/Annotation/Service.php
+++ b/Annotation/Service.php
@@ -18,8 +18,6 @@
 
 namespace JMS\DiExtraBundle\Annotation;
 
-use JMS\DiExtraBundle\Exception\InvalidTypeException;
-
 /**
  * @Annotation
  * @Target("CLASS")
@@ -40,6 +38,9 @@ final class Service
 
     /** @var boolean */
     public $abstract;
+
+    /** @var boolean */
+    public $lazy;
 
     /** @var array<string> */
     public $environments = array();

--- a/Metadata/ClassMetadata.php
+++ b/Metadata/ClassMetadata.php
@@ -27,6 +27,7 @@ class ClassMetadata extends BaseClassMetadata
     public $scope;
     public $public;
     public $abstract;
+    public $lazy;
     public $tags = array();
     public $arguments;
     public $methodCalls = array();
@@ -52,6 +53,7 @@ class ClassMetadata extends BaseClassMetadata
             $this->scope,
             $this->public,
             $this->abstract,
+            $this->lazy,
             $this->tags,
             $this->arguments,
             $this->methodCalls,
@@ -73,6 +75,7 @@ class ClassMetadata extends BaseClassMetadata
             $this->scope,
             $this->public,
             $this->abstract,
+            $this->lazy,
             $this->tags,
             $this->arguments,
             $this->methodCalls,

--- a/Metadata/ClassMetadata.php
+++ b/Metadata/ClassMetadata.php
@@ -85,8 +85,8 @@ class ClassMetadata extends BaseClassMetadata
             $parentStr
         ) = $data;
 
-        if (isset($data[12])) {
-            $this->environments = $data[12];
+        if (isset($data[13])) {
+            $this->environments = $data[13];
         }
 
         parent::unserialize($parentStr);

--- a/Metadata/Driver/AnnotationDriver.php
+++ b/Metadata/Driver/AnnotationDriver.php
@@ -82,6 +82,7 @@ class AnnotationDriver implements DriverInterface
                 $metadata->public = $annot->public;
                 $metadata->scope = $annot->scope;
                 $metadata->abstract = $annot->abstract;
+                $metadata->lazy = $annot->lazy;
             } else if ($annot instanceof Tag) {
                 $metadata->tags[$annot->name][] = $annot->attributes;
             } else if ($annot instanceof Validator) {

--- a/Metadata/MetadataConverter.php
+++ b/Metadata/MetadataConverter.php
@@ -56,6 +56,9 @@ class MetadataConverter
             if (null !== $classMetadata->abstract) {
                 $definition->setAbstract($classMetadata->abstract);
             }
+            if (null !== $classMetadata->lazy) {
+                $definition->setLazy($classMetadata->lazy);
+            }
             if (null !== $classMetadata->arguments) {
                 $definition->setArguments($classMetadata->arguments);
             }

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,8 @@
         "jms/security-extra-bundle": "1.*",
         "doctrine/doctrine-bundle": "*",
         "doctrine/orm": "*",
-        "phpcollection/phpcollection": ">=0.1,<0.3-dev"
+        "phpcollection/phpcollection": ">=0.1,<0.3-dev",
+        "ocramius/proxy-manager": "~1.0"
     },
     "autoload": {
         "psr-0": { "JMS\\DiExtraBundle": "" }

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
         "symfony/process": "~2.1",
         "symfony/finder": "~2.1",
         "jms/aop-bundle": "^1.1.0",
-        "jms/metadata": "1.*"
+        "jms/metadata": "1.*",
+        "ocramius/proxy-manager": "~1.0"
     },
     "require-dev": {
         "symfony/validator": "*",
@@ -30,8 +31,7 @@
         "jms/security-extra-bundle": "1.*",
         "doctrine/doctrine-bundle": "*",
         "doctrine/orm": "*",
-        "phpcollection/phpcollection": ">=0.1,<0.3-dev",
-        "ocramius/proxy-manager": "~1.0"
+        "phpcollection/phpcollection": ">=0.1,<0.3-dev"
     },
     "autoload": {
         "psr-0": { "JMS\\DiExtraBundle": "" }


### PR DESCRIPTION
Wouldn't it be nice to define lazy services in Service annotation?

```
/**
 * @Service("my_service", lazy=true)
 */
class MyService { ... }
```

Just by adding "ocramius/proxy-manager" as dependency and handling Service "lazy" property you can make it. I hope you find this pull request useful

Cheers