### PR TITLE
"Lazy" property in Service annotation: Define service as lazy

### DIFF
--- a/Annotation/Service.php
+++ b/Annotation/Service.php
@@ -48,6 +48,9 @@ final class Service
     /** @var boolean */
     public $abstract;
 
+    /** @var boolean */
+    public $lazy;
+
     /** @var array<string> */
     public $environments = array();
 }

--- a/DependencyInjection/JMSDiExtraExtension.php
+++ b/DependencyInjection/JMSDiExtraExtension.php
@@ -152,7 +152,9 @@ class JMSDiExtraExtension extends Extension
 
             // clear the cache if container is re-build, needed for correct controller injections
             $fs = new Filesystem();
-            $fs->remove($cacheDir);
+            if ($fs->exists($cacheDir)) {
+                $fs->remove($cacheDir);
+            }
 
             if (!file_exists($cacheDir)) {
                 if (false === @mkdir($cacheDir, 0777, true)) {

--- a/Exception/InvalidAnnotationException.php
+++ b/Exception/InvalidAnnotationException.php
@@ -16,38 +16,7 @@
  * limitations under the License.
  */
 
-namespace JMS\DiExtraBundle\Annotation;
+namespace JMS\DiExtraBundle\Exception;
 
-/**
- * @Annotation
- * @Target("CLASS")
- */
-final class Service
-{
-    /** @var string */
-    public $id;
-
-    /** @var string */
-    public $parent;
-
-    /** @var boolean */
-    public $public;
-
-    /** @var string */
-    public $scope;
-
-    /** @var string */
-    public $deprecated;
-
-    /** @var string */
-    public $decorates;
-
-    /** @var string */
-    public $decoration_inner_name;
-
-    /** @var boolean */
-    public $abstract;
-
-    /** @var array<string> */
-    public $environments = array();
-}
+class InvalidAnnotationException extends \InvalidArgumentException implements Exception
+{}

--- a/Generator/DefinitionInjectorGenerator.php
+++ b/Generator/DefinitionInjectorGenerator.php
@@ -109,10 +109,6 @@ class DefinitionInjectorGenerator
             }
         }
 
-        if (method_exists($def, 'getInitMethod') && $def->getInitMethod()) {
-            $writer->writeln('$instance->'.$def->getInitMethod().'();');
-        }
-
         $writer
             ->writeln('return $instance;')
             ->outdent()

--- a/Metadata/ClassMetadata.php
+++ b/Metadata/ClassMetadata.php
@@ -35,7 +35,11 @@ class ClassMetadata extends BaseClassMetadata
     public $methodCalls = array();
     public $lookupMethods = array();
     public $properties = array();
+    /**
+     * @deprecated since version 1.7, to be removed in 2.0. Use $initMethods instead.
+     */
     public $initMethod;
+    public $initMethods = array();
     public $environments = array();
     public $decorates;
     public $decoration_inner_name;

--- a/Metadata/ClassMetadata.php
+++ b/Metadata/ClassMetadata.php
@@ -20,6 +20,9 @@ namespace JMS\DiExtraBundle\Metadata;
 
 use Metadata\ClassMetadata as BaseClassMetadata;
 
+/**
+ * class metadata
+ */
 class ClassMetadata extends BaseClassMetadata
 {
     public $id;
@@ -34,7 +37,15 @@ class ClassMetadata extends BaseClassMetadata
     public $properties = array();
     public $initMethod;
     public $environments = array();
+    public $decorates;
+    public $decoration_inner_name;
+    public $deprecated;
 
+    /**
+     * @param string $env
+     *
+     * @return bool
+     */
     public function isLoadedInEnvironment($env)
     {
         if (empty($this->environments)) {
@@ -44,6 +55,9 @@ class ClassMetadata extends BaseClassMetadata
         return in_array($env, $this->environments, true);
     }
 
+    /**
+     * @return string
+     */
     public function serialize()
     {
         return serialize(array(
@@ -60,14 +74,21 @@ class ClassMetadata extends BaseClassMetadata
             $this->initMethod,
             parent::serialize(),
             $this->environments,
+            $this->decorates,
+            $this->decoration_inner_name,
+            $this->deprecated,
         ));
     }
 
+    /**
+     * @param string $str
+     */
     public function unserialize($str)
     {
         $data = unserialize($str);
 
-        list(
+        // prevent errors if not all key's are set
+        @list(
             $this->id,
             $this->parent,
             $this->scope,
@@ -79,12 +100,12 @@ class ClassMetadata extends BaseClassMetadata
             $this->lookupMethods,
             $this->properties,
             $this->initMethod,
-            $parentStr
+            $parentStr,
+            $this->environments,
+            $this->decorates,
+            $this->decoration_inner_name,
+            $this->deprecated,
         ) = $data;
-
-        if (isset($data[12])) {
-            $this->environments = $data[12];
-        }
 
         parent::unserialize($parentStr);
     }

--- a/Metadata/ClassMetadata.php
+++ b/Metadata/ClassMetadata.php
@@ -114,6 +114,10 @@ class ClassMetadata extends BaseClassMetadata
             $this->deprecated,
         ) = $data;
 
+        if (isset($data[13])) {
+            $this->environments = $data[13];
+        }
+
         parent::unserialize($parentStr);
     }
 }

--- a/Metadata/ClassMetadata.php
+++ b/Metadata/ClassMetadata.php
@@ -30,6 +30,7 @@ class ClassMetadata extends BaseClassMetadata
     public $scope;
     public $public;
     public $abstract;
+    public $lazy;
     public $tags = array();
     public $arguments;
     public $methodCalls = array();
@@ -70,6 +71,7 @@ class ClassMetadata extends BaseClassMetadata
             $this->scope,
             $this->public,
             $this->abstract,
+            $this->lazy,
             $this->tags,
             $this->arguments,
             $this->methodCalls,
@@ -98,6 +100,7 @@ class ClassMetadata extends BaseClassMetadata
             $this->scope,
             $this->public,
             $this->abstract,
+            $this->lazy,
             $this->tags,
             $this->arguments,
             $this->methodCalls,

--- a/Metadata/Driver/AnnotationDriver.php
+++ b/Metadata/Driver/AnnotationDriver.php
@@ -82,6 +82,9 @@ class AnnotationDriver implements DriverInterface
                 $metadata->public = $annot->public;
                 $metadata->scope = $annot->scope;
                 $metadata->abstract = $annot->abstract;
+                $metadata->decorates = $annot->decorates;
+                $metadata->decoration_inner_name = $annot->decoration_inner_name;
+                $metadata->deprecated = $annot->deprecated;
             } else if ($annot instanceof Tag) {
                 $metadata->tags[$annot->name][] = $annot->attributes;
             } else if ($annot instanceof Validator) {

--- a/Metadata/Driver/AnnotationDriver.php
+++ b/Metadata/Driver/AnnotationDriver.php
@@ -85,6 +85,7 @@ class AnnotationDriver implements DriverInterface
                 $metadata->decorates = $annot->decorates;
                 $metadata->decoration_inner_name = $annot->decoration_inner_name;
                 $metadata->deprecated = $annot->deprecated;
+                $metadata->lazy = $annot->lazy;
             } else if ($annot instanceof Tag) {
                 $metadata->tags[$annot->name][] = $annot->attributes;
             } else if ($annot instanceof Validator) {

--- a/Metadata/Driver/AnnotationDriver.php
+++ b/Metadata/Driver/AnnotationDriver.php
@@ -209,6 +209,7 @@ class AnnotationDriver implements DriverInterface
                     }
 
                     $metadata->initMethod = $method->name;
+                    $metadata->initMethods[] = $method->name;
                 } else if ($annot instanceof MetadataProcessorInterface) {
                     if (null === $metadata->id) {
                         $metadata->id = $this->namingStrategy->classToServiceName($className);

--- a/Metadata/MetadataConverter.php
+++ b/Metadata/MetadataConverter.php
@@ -69,11 +69,7 @@ class MetadataConverter
             }
 
             if ($classMetadata->initMethod) {
-                if (!method_exists($definition, 'setInitMethod')) {
-                    throw new \RuntimeException(sprintf('@AfterSetup is not available on your Symfony version.'));
-                }
-
-                $definition->setInitMethod($classMetadata->initMethod);
+                throw new \RuntimeException(sprintf('You can\'t use @AfterSetup on a service.'));
             }
 
             $definitions[$classMetadata->id] = $definition;

--- a/Metadata/MetadataConverter.php
+++ b/Metadata/MetadataConverter.php
@@ -57,6 +57,9 @@ class MetadataConverter
             if (null !== $classMetadata->abstract) {
                 $definition->setAbstract($classMetadata->abstract);
             }
+            if (null !== $classMetadata->lazy) {
+                $definition->setLazy($classMetadata->lazy);
+            }
             if (null !== $classMetadata->arguments) {
                 $definition->setArguments($classMetadata->arguments);
             }

--- a/Metadata/MetadataConverter.php
+++ b/Metadata/MetadataConverter.php
@@ -18,6 +18,7 @@
 
 namespace JMS\DiExtraBundle\Metadata;
 
+use JMS\DiExtraBundle\Exception\InvalidAnnotationException;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\DefinitionDecorator;
 use Symfony\Component\DependencyInjection\Definition;
@@ -63,6 +64,23 @@ class MetadataConverter
             $definition->setMethodCalls($classMetadata->methodCalls);
             $definition->setTags($classMetadata->tags);
             $definition->setProperties($classMetadata->properties);
+
+            if (null !== $classMetadata->decorates) {
+                if (!method_exists($definition, 'setDecoratedService')) {
+                    throw new InvalidAnnotationException(
+                        sprintf(
+                            "decorations require symfony >=2.8 on class %s",
+                            $classMetadata->name
+                        )
+                    );
+                }
+
+                $definition->setDecoratedService($classMetadata->decorates, $classMetadata->decoration_inner_name);
+            }
+
+            if (null !== $classMetadata->deprecated && method_exists($definition, 'setDeprecated')) {
+                $definition->setDeprecated(true, $classMetadata->deprecated);
+            }
 
             if (null === $classMetadata->id) {
                 $classMetadata->id = '_jms_di_extra.unnamed.service_'.$count++;

--- a/Metadata/MetadataConverter.php
+++ b/Metadata/MetadataConverter.php
@@ -86,12 +86,13 @@ class MetadataConverter
                 $classMetadata->id = '_jms_di_extra.unnamed.service_'.$count++;
             }
 
-            if ($classMetadata->initMethod) {
-                if (!method_exists($definition, 'setInitMethod')) {
-                    throw new \RuntimeException(sprintf('@AfterSetup is not available on your Symfony version.'));
+            if (0 !== count($classMetadata->initMethods)) {
+                foreach ($classMetadata->initMethods as $initMethod) {
+                    $definition->addMethodCall($initMethod);
                 }
-
-                $definition->setInitMethod($classMetadata->initMethod);
+            } elseif (null !== $classMetadata->initMethod) {
+                @trigger_error('ClassMetadata::$initMethod is deprecated since version 1.7 and will be removed in 2.0. Use ClassMetadata::$initMethods instead.', E_USER_DEPRECATED);
+                $definition->addMethodCall($classMetadata->initMethod);
             }
 
             $definitions[$classMetadata->id] = $definition;

--- a/Metadata/MetadataConverter.php
+++ b/Metadata/MetadataConverter.php
@@ -69,7 +69,11 @@ class MetadataConverter
             }
 
             if ($classMetadata->initMethod) {
-                throw new \RuntimeException(sprintf('You can\'t use @AfterSetup on a service.'));
+                if (!method_exists($definition, 'setInitMethod')) {
+                    throw new \RuntimeException(sprintf('@AfterSetup is not available on your Symfony version.'));
+                }
+
+                $definition->setInitMethod($classMetadata->initMethod);
             }
 
             $definitions[$classMetadata->id] = $definition;

--- a/Tests/Metadata/ClassMetadataTest.php
+++ b/Tests/Metadata/ClassMetadataTest.php
@@ -29,6 +29,9 @@ class ClassMetadataTest extends \PHPUnit_Framework_TestCase
         $classMetadata->abstract = true;
         $classMetadata->public = false;
         $classMetadata->id = 'foo';
+        $classMetadata->deprecated = true;
+        $classMetadata->decorates = 'test.service';
+        $classMetadata->decoration_inner_name = 'old.test.service';
 
         $this->assertEquals($classMetadata, unserialize(serialize($classMetadata)));
     }

--- a/Tests/Metadata/Driver/AnnotationDriverTest.php
+++ b/Tests/Metadata/Driver/AnnotationDriverTest.php
@@ -37,6 +37,16 @@ class AnnotationDriverTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('works', @$metadata->tags['custom'], 'check value of custom annotation');
     }
 
+    public function testServiceAnnotations()
+    {
+        $metadata = $this->getDriver()->loadMetadataForClass(new \ReflectionClass('JMS\DiExtraBundle\Tests\Metadata\Driver\Fixture\Service'));
+        $this->assertEquals('test.service', $metadata->id);
+        $this->assertEquals('test.service', $metadata->decorates);
+        $this->assertEquals('original.test.service', $metadata->decoration_inner_name);
+        $this->assertEquals('use new.test.service instead', $metadata->deprecated);
+        $this->assertEquals(false, $metadata->public);
+    }
+
     public function testCustomAnnotationOnMethod()
     {
         $metadata = $this->getDriver()->loadMetadataForClass(new \ReflectionClass('JMS\DiExtraBundle\Tests\Metadata\Driver\Fixture\MethodMetaProcessor'));

--- a/Tests/Metadata/Driver/Fixture/Service.php
+++ b/Tests/Metadata/Driver/Fixture/Service.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace JMS\DiExtraBundle\Tests\Metadata\Driver\Fixture;
+
+use JMS\DiExtraBundle\Annotation as DI; // Use this alias in order to not have this class picked up by the finder
+
+/**
+ * @DI\Service(
+ *     id="test.service",
+ *     decorates="test.service",
+ *     decoration_inner_name="original.test.service",
+ *     deprecated="use new.test.service instead",
+ *     public=false
+ * )
+ *
+ * @author wodka
+ */
+class Service
+{
+}

--- a/composer.json
+++ b/composer.json
@@ -20,11 +20,6 @@
         "symfony/finder": "~2.3|~3.0",
         "jms/aop-bundle": "~1.1",
         "jms/metadata": "~1.0",
-        "symfony/framework-bundle": "~2.1",
-        "symfony/process": "~2.1",
-        "symfony/finder": "~2.1",
-        "jms/aop-bundle": "^1.1.0",
-        "jms/metadata": "1.*",
         "ocramius/proxy-manager": "~1.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
         "symfony/process": "~2.3|~3.0",
         "symfony/finder": "~2.3|~3.0",
         "jms/aop-bundle": "~1.1",
-        "jms/metadata": "~1.0"
+        "jms/metadata": "~1.0",
+        "ocramius/proxy-manager": "~1.0"
     },
     "require-dev": {
         "symfony/validator": "~2.3|~3.0",

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,11 @@
         "symfony/finder": "~2.3|~3.0",
         "jms/aop-bundle": "~1.1",
         "jms/metadata": "~1.0",
+        "symfony/framework-bundle": "~2.1",
+        "symfony/process": "~2.1",
+        "symfony/finder": "~2.1",
+        "jms/aop-bundle": "^1.1.0",
+        "jms/metadata": "1.*",
         "ocramius/proxy-manager": "~1.0"
     },
     "require-dev": {


### PR DESCRIPTION
Wouldn't it be nice to define lazy services in Service annotation?

```
/**
 * @Service("my_service", lazy=true)
 */
class MyService { ... }
```

Just by adding "ocramius/proxy-manager" as dependency and handling Service "lazy" property you can make it. I hope you find this pull request useful

Cheers