### PR TITLE
Enable Controllers without injection (have been missing from ClassHierachy)

### DIFF
--- a/Generator/DefinitionInjectorGenerator.php
+++ b/Generator/DefinitionInjectorGenerator.php
@@ -84,10 +84,10 @@ class DefinitionInjectorGenerator
             $name = $this->nameGenerator->nextName();
             $this->inlinedDefinitions[$inlineDef] = $name;
 
-            $writer->writeln('$'.$name.' = new \\'.ltrim($inlineDef->getClass(), "\\").$this->dumpArguments($inlineDef->getArguments()).';');
+            $writer->writeln('$'.$name.' = new '.$this->dumpClassName($inlineDef).$this->dumpArguments($inlineDef->getArguments()).';');
         }
 
-        $writer->writeln('$instance = new \\'.ltrim($def->getClass(), "\\").$this->dumpArguments($def->getArguments()).';');
+        $writer->writeln('$instance = new '.$this->dumpClassName($def).$this->dumpArguments($def->getArguments()).';');
 
         foreach ($def->getMethodCalls() as $call) {
             list($method, $arguments) = $call;
@@ -174,6 +174,15 @@ class DefinitionInjectorGenerator
                 $this->getDefinitionsFromArray($v, $defs);
             }
         }
+    }
+
+    /**
+     * @param Definition $definition
+     * @return string
+     */
+    private function dumpClassName(Definition $definition)
+    {
+        return '\\'.ltrim($definition->getClass(), "\\");
     }
 
     private function dumpArguments(array $arguments)

--- a/Tests/Functional/Bundle/TestBundle/Controller/Base/BarController.php
+++ b/Tests/Functional/Bundle/TestBundle/Controller/Base/BarController.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace JMS\DiExtraBundle\Tests\Functional\Bundle\TestBundle\Controller\Base;
+
+use JMS\DiExtraBundle\Annotation as DI;
+use Symfony\Component\HttpFoundation\Response;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+
+class BarController extends Controller
+{
+    /**
+     * @DI\Inject("%bar%")
+     */
+    protected $bar;
+
+    /**
+     * @Route("/base/bar")
+     *
+     * @return Response
+     */
+    public function barAction()
+    {
+        return new Response($this->bar);
+    }
+}

--- a/Tests/Functional/Bundle/TestBundle/Controller/Base/Controller.php
+++ b/Tests/Functional/Bundle/TestBundle/Controller/Base/Controller.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace JMS\DiExtraBundle\Tests\Functional\Bundle\TestBundle\Controller\Base;
+
+use Symfony\Bundle\FrameworkBundle\Controller\Controller as BaseController;
+use JMS\DiExtraBundle\Annotation as DI;
+
+class Controller extends BaseController
+{
+    /**
+     * @DI\Inject("%foo%")
+     */
+    protected $foo;
+}

--- a/Tests/Functional/Bundle/TestBundle/Controller/Base/FooController.php
+++ b/Tests/Functional/Bundle/TestBundle/Controller/Base/FooController.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace JMS\DiExtraBundle\Tests\Functional\Bundle\TestBundle\Controller\Base;
+
+use JMS\DiExtraBundle\Annotation as DI;
+use Symfony\Component\HttpFoundation\Response;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+
+class FooController extends Controller
+{
+    /**
+     * @Route("/base/foo")
+     *
+     * @return Response
+     */
+    public function indexAction()
+    {
+        return new Response($this->foo);
+    }
+}

--- a/Tests/Functional/Issue39Test.php
+++ b/Tests/Functional/Issue39Test.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * Copyright 2011 Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace JMS\DiExtraBundle\Tests\Functional;
+
+class Issue39Test extends BaseTestCase
+{
+    /**
+     * @runInSeparateProcess
+     */
+    public function testControllerWithInjection()
+    {
+        $client = $this->createClient();
+        $client->request('GET', '/base/bar');
+
+        $bar = self::$kernel->getContainer()->getParameter('bar');
+
+        $this->assertEquals($bar, $client->getResponse()->getContent());
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testControllerWithoutInjection()
+    {
+        $client = $this->createClient();
+        $client->request('GET', '/base/foo');
+
+        $foo = self::$kernel->getContainer()->getParameter('foo');
+
+        $this->assertEquals($foo, $client->getResponse()->getContent());
+    }
+}

--- a/Tests/Functional/config/default.yml
+++ b/Tests/Functional/config/default.yml
@@ -13,3 +13,7 @@ services:
     controller.hello:
         class: JMS\DiExtraBundle\Tests\Functional\Bundle\TestBundle\Controller\ServiceController
         arguments: [ "@router" ]
+
+parameters:
+    foo: "foo"
+    bar: "bar"


### PR DESCRIPTION
Some controllers might not have an injection defined, those get removed by the metadataFactory because no metadata is preset, but we still need them in the path to have it working