### PR TITLE
ControllerResolver conflicts

### DIFF
--- a/Tests/Functional/Bundle/TestBundle/Controller/InvokableServiceController.php
+++ b/Tests/Functional/Bundle/TestBundle/Controller/InvokableServiceController.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace JMS\DiExtraBundle\Tests\Functional\Bundle\TestBundle\Controller;
+
+use Symfony\Component\HttpFoundation\Response;
+use JMS\DiExtraBundle\Annotation as DI;
+
+/**
+ * @DI\Service("controller.invokable")
+ */
+class InvokableServiceController
+{
+    public function __invoke()
+    {
+        return new Response('invoked');
+    }
+}

--- a/Tests/Functional/ControllerResolverTest.php
+++ b/Tests/Functional/ControllerResolverTest.php
@@ -67,4 +67,15 @@ class ControllerResolverTest extends BaseTestCase
 
         $this->assertEquals('hello', $client->getResponse()->getContent());
     }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testInvokableControllerAsService()
+    {
+        $client = $this->createClient();
+        $client->request('GET', '/invoke');
+
+        $this->assertEquals('invoked', $client->getResponse()->getContent());
+    }
 }

--- a/Tests/Functional/config/default.yml
+++ b/Tests/Functional/config/default.yml
@@ -13,3 +13,6 @@ services:
     controller.hello:
         class: JMS\DiExtraBundle\Tests\Functional\Bundle\TestBundle\Controller\ServiceController
         arguments: [ "@router" ]
+
+sensio_framework_extra:
+    request: { converters: false }

--- a/Tests/Functional/config/routing.yml
+++ b/Tests/Functional/config/routing.yml
@@ -6,3 +6,8 @@ hello:
     path: /hello
     defaults:
         _controller: controller.extended_hello:helloAction
+
+invoke:
+    path: /invoke
+    defaults:
+        _controller: controller.invokable


### PR DESCRIPTION
Hi,

This PR will help to keep up with the [`ControllerResolver`](https://github.com/symfony/framework-bundle/blob/3.0/Controller/ControllerResolver.php) from the Symfony Framework Bundle.
~~The switch required to find the form of the supplied controller should be kept in Symfony, and this bundle should only focus on changing the way the controller is instanciated.~~
> method `instantiateController` doesn't exist in 2.3

Also it will naturally add the support proposed in #192 by @adam187 (thx for the tests btw)

Last but not the least, it add supports for pre-defined services that should'nt be messed with at all, as seen in https://github.com/dunglas/DunglasActionBundle/commit/b4e1fa0b56f4a831772d34c58b0bd58b8c318b27 to work with https://github.com/dunglas/DunglasActionBundle.

In fact, it was the reason I stopped by in the first place, I had a conflict between those 2 bundles... :sweat_smile:

Cheers.

> Also I didn't test that out, but it might help on issues #126 and #124 