### PR TITLE
Add shared service parameter (replaces scope SF3)

### DIFF
--- a/Annotation/Service.php
+++ b/Annotation/Service.php
@@ -36,6 +36,9 @@ final class Service
     /** @var string */
     public $scope;
 
+    /** @var boolean */
+    public $shared;
+
     /** @var string */
     public $deprecated;
 

--- a/Metadata/ClassMetadata.php
+++ b/Metadata/ClassMetadata.php
@@ -28,6 +28,7 @@ class ClassMetadata extends BaseClassMetadata
     public $id;
     public $parent;
     public $scope;
+    public $shared;
     public $public;
     public $abstract;
     public $tags = array();
@@ -68,6 +69,7 @@ class ClassMetadata extends BaseClassMetadata
             $this->id,
             $this->parent,
             $this->scope,
+            $this->shared,
             $this->public,
             $this->abstract,
             $this->tags,
@@ -97,6 +99,7 @@ class ClassMetadata extends BaseClassMetadata
             $this->id,
             $this->parent,
             $this->scope,
+            $this->shared,
             $this->public,
             $this->abstract,
             $this->tags,

--- a/Metadata/Driver/AnnotationDriver.php
+++ b/Metadata/Driver/AnnotationDriver.php
@@ -81,6 +81,7 @@ class AnnotationDriver implements DriverInterface
                 $metadata->parent = $annot->parent;
                 $metadata->public = $annot->public;
                 $metadata->scope = $annot->scope;
+                $metadata->shared = $annot->shared;
                 $metadata->abstract = $annot->abstract;
                 $metadata->decorates = $annot->decorates;
                 $metadata->decoration_inner_name = $annot->decoration_inner_name;

--- a/Metadata/MetadataConverter.php
+++ b/Metadata/MetadataConverter.php
@@ -51,6 +51,9 @@ class MetadataConverter
             if (null !== $classMetadata->scope) {
                 $definition->setScope($classMetadata->scope);
             }
+            if (null !== $classMetadata->shared) {
+                $definition->setShared($classMetadata->shared);
+            }
             if (null !== $classMetadata->public) {
                 $definition->setPublic($classMetadata->public);
             }


### PR DESCRIPTION
Was using some prototype scoped services which were removed in 3.0 in favor of shared = false.

Ref: https://github.com/symfony/symfony/blob/master/UPGRADE-3.0.md#dependencyinjection


I am not sure of any implications of doing this and leaving both available regardless of Symfony version so let me know if there is a better strategy to solve this problem.