### PR TITLE
Activated the support for environments in @Service annotation

### DIFF
--- a/Metadata/Driver/AnnotationDriver.php
+++ b/Metadata/Driver/AnnotationDriver.php
@@ -85,6 +85,7 @@ class AnnotationDriver implements DriverInterface
                 $metadata->decorates = $annot->decorates;
                 $metadata->decoration_inner_name = $annot->decoration_inner_name;
                 $metadata->deprecated = $annot->deprecated;
+                $metadata->environments = $annot->environments;
             } else if ($annot instanceof Tag) {
                 $metadata->tags[$annot->name][] = $annot->attributes;
             } else if ($annot instanceof Validator) {

--- a/Tests/Metadata/Driver/AnnotationDriverTest.php
+++ b/Tests/Metadata/Driver/AnnotationDriverTest.php
@@ -41,6 +41,7 @@ class AnnotationDriverTest extends \PHPUnit_Framework_TestCase
     {
         $metadata = $this->getDriver()->loadMetadataForClass(new \ReflectionClass('JMS\DiExtraBundle\Tests\Metadata\Driver\Fixture\Service'));
         $this->assertEquals('test.service', $metadata->id);
+        $this->assertEquals(array('dev', 'test'), $metadata->environments);
         $this->assertEquals('test.service', $metadata->decorates);
         $this->assertEquals('original.test.service', $metadata->decoration_inner_name);
         $this->assertEquals('use new.test.service instead', $metadata->deprecated);

--- a/Tests/Metadata/Driver/Fixture/Service.php
+++ b/Tests/Metadata/Driver/Fixture/Service.php
@@ -7,6 +7,7 @@ use JMS\DiExtraBundle\Annotation as DI; // Use this alias in order to not have t
 /**
  * @DI\Service(
  *     id="test.service",
+ *     environments={"dev", "test"},
  *     decorates="test.service",
  *     decoration_inner_name="original.test.service",
  *     deprecated="use new.test.service instead",


### PR DESCRIPTION
For some reason, the environments property from the `@Service` annotation was not passed onto the `metadata`. 