### PR TITLE
Support for Symfony 2.8+ autowiring

### DIFF
--- a/Annotation/Service.php
+++ b/Annotation/Service.php
@@ -53,4 +53,10 @@ final class Service
 
     /** @var array<string> */
     public $environments = array();
+
+    /** @var boolean */
+    public $autowire;
+
+    /** @var array<string> */
+    public $autowiringTypes;
 }

--- a/Metadata/ClassMetadata.php
+++ b/Metadata/ClassMetadata.php
@@ -46,6 +46,9 @@ class ClassMetadata extends BaseClassMetadata
     public $decoration_inner_name;
     public $deprecated;
 
+    public $autowire;
+    public $autowiringTypes;
+
     /**
      * @param string $env
      *
@@ -72,12 +75,14 @@ class ClassMetadata extends BaseClassMetadata
             $this->shared,
             $this->public,
             $this->abstract,
+            $this->autowire,
             $this->tags,
             $this->arguments,
             $this->methodCalls,
             $this->lookupMethods,
             $this->properties,
             $this->initMethod,
+            $this->autowiringTypes,
             parent::serialize(),
             $this->environments,
             $this->decorates,
@@ -102,12 +107,14 @@ class ClassMetadata extends BaseClassMetadata
             $this->shared,
             $this->public,
             $this->abstract,
+            $this->autowire,
             $this->tags,
             $this->arguments,
             $this->methodCalls,
             $this->lookupMethods,
             $this->properties,
             $this->initMethod,
+            $this->autowiringTypes,
             $parentStr,
             $this->environments,
             $this->decorates,

--- a/Metadata/Driver/AnnotationDriver.php
+++ b/Metadata/Driver/AnnotationDriver.php
@@ -87,6 +87,8 @@ class AnnotationDriver implements DriverInterface
                 $metadata->decoration_inner_name = $annot->decoration_inner_name;
                 $metadata->deprecated = $annot->deprecated;
                 $metadata->environments = $annot->environments;
+                $metadata->autowire = $annot->autowire;
+                $metadata->autowiringTypes = $annot->autowiringTypes;
             } else if ($annot instanceof Tag) {
                 $metadata->tags[$annot->name][] = $annot->attributes;
             } else if ($annot instanceof Validator) {

--- a/Metadata/MetadataConverter.php
+++ b/Metadata/MetadataConverter.php
@@ -63,7 +63,18 @@ class MetadataConverter
             if (null !== $classMetadata->arguments) {
                 $definition->setArguments($classMetadata->arguments);
             }
+            if (null !== $classMetadata->autowire) {
+                if (!method_exists($definition, 'setAutowire')) {
+                    throw new InvalidAnnotationException(sprintf('You must use symfony 2.8 or higher to use autowiring on the class %s.', $classMetadata->name));
+                }
 
+                $definition->setAutowire($classMetadata->autowire);
+            }
+            if (null !== $classMetadata->autowiringTypes && method_exists($definition, 'setAutowiringTypes')) {
+                $definition->setAutowiringTypes($classMetadata->autowiringTypes);
+            }
+
+            
             $definition->setMethodCalls($classMetadata->methodCalls);
             $definition->setTags($classMetadata->tags);
             $definition->setProperties($classMetadata->properties);

--- a/Metadata/MetadataConverter.php
+++ b/Metadata/MetadataConverter.php
@@ -70,12 +70,7 @@ class MetadataConverter
 
             if (null !== $classMetadata->decorates) {
                 if (!method_exists($definition, 'setDecoratedService')) {
-                    throw new InvalidAnnotationException(
-                        sprintf(
-                            "decorations require symfony >=2.8 on class %s",
-                            $classMetadata->name
-                        )
-                    );
+                    throw new InvalidAnnotationException(sprintf('You must use symfony 2.8 or higher to use decorations on the class %s.', $classMetadata->name));
                 }
 
                 $definition->setDecoratedService($classMetadata->decorates, $classMetadata->decoration_inner_name);

--- a/Tests/Metadata/ClassMetadataTest.php
+++ b/Tests/Metadata/ClassMetadataTest.php
@@ -32,6 +32,8 @@ class ClassMetadataTest extends \PHPUnit_Framework_TestCase
         $classMetadata->deprecated = true;
         $classMetadata->decorates = 'test.service';
         $classMetadata->decoration_inner_name = 'old.test.service';
+        $classMetadata->autowire = true;
+        $classMetadata->autowiringTypes = array('JMS\DiExtraBundle\Tests\Fixture\LoginController');
 
         $this->assertEquals($classMetadata, unserialize(serialize($classMetadata)));
     }

--- a/Tests/Metadata/Driver/AnnotationDriverTest.php
+++ b/Tests/Metadata/Driver/AnnotationDriverTest.php
@@ -46,6 +46,7 @@ class AnnotationDriverTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('original.test.service', $metadata->decoration_inner_name);
         $this->assertEquals('use new.test.service instead', $metadata->deprecated);
         $this->assertEquals(false, $metadata->public);
+        $this->assertEquals(array('JMS\DiExtraBundle\Tests\Metadata\Driver\Fixture\Service'), $metadata->autowiringTypes);
     }
 
     public function testCustomAnnotationOnMethod()

--- a/Tests/Metadata/Driver/Fixture/Service.php
+++ b/Tests/Metadata/Driver/Fixture/Service.php
@@ -11,7 +11,9 @@ use JMS\DiExtraBundle\Annotation as DI; // Use this alias in order to not have t
  *     decorates="test.service",
  *     decoration_inner_name="original.test.service",
  *     deprecated="use new.test.service instead",
- *     public=false
+ *     public=false,
+ *     autowire=false,
+ *     autowiringTypes={"JMS\DiExtraBundle\Tests\Metadata\Driver\Fixture\Service"}
  * )
  *
  * @author wodka

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
         "symfony/yaml": "~2.3|~3.0",
         "symfony/browser-kit": "~2.3|~3.0",
         "symfony/security-bundle": "~2.3",
+        "symfony/expression-language": "~2.6|~3.0",
         "symfony/twig-bundle": "~2.3|~3.0",
         "sensio/framework-extra-bundle": "~2.0|~3.0",
         "jms/security-extra-bundle": "~1.0",


### PR DESCRIPTION
Here is the PR proposed in #253 

I also added a dev dependency on symfony/expression-language because the functional tests were crashing otherwise.

I updated the tests to include testing for the support of autowiring, as much as I could understand the current structure of the tests. Tell me if you see any test case I should add.

I took the option to throw an exception if we use "autowire" with a version of Symfony that doesn't support it. However, autowiringType is silently ignored if there is no support for it.