### PR TITLE
Rename decoration_inner_name to decorationInnerName

### DIFF
--- a/Annotation/Service.php
+++ b/Annotation/Service.php
@@ -45,8 +45,14 @@ final class Service
     /** @var string */
     public $decorates;
 
-    /** @var string */
+    /**
+     * @var string
+     * @deprecated since version 1.8, to be removed in 2.0. Use $decorationInnerName instead.
+     */
     public $decoration_inner_name;
+
+    /** @var string */
+    public $decorationInnerName;
 
     /** @var boolean */
     public $abstract;

--- a/Metadata/ClassMetadata.php
+++ b/Metadata/ClassMetadata.php
@@ -43,6 +43,10 @@ class ClassMetadata extends BaseClassMetadata
     public $initMethods = array();
     public $environments = array();
     public $decorates;
+    public $decorationInnerName;
+    /**
+     * @deprecated since version 1.8, to be removed in 2.0. Use $initMethods instead.
+     */
     public $decoration_inner_name;
     public $deprecated;
 
@@ -87,6 +91,7 @@ class ClassMetadata extends BaseClassMetadata
             $this->environments,
             $this->decorates,
             $this->decoration_inner_name,
+            $this->decorationInnerName,
             $this->deprecated,
             $this->initMethods,
         ));
@@ -119,6 +124,7 @@ class ClassMetadata extends BaseClassMetadata
             $this->environments,
             $this->decorates,
             $this->decoration_inner_name,
+            $this->decorationInnerName,
             $this->deprecated,
             $this->initMethods,
         ) = $data;

--- a/Metadata/Driver/AnnotationDriver.php
+++ b/Metadata/Driver/AnnotationDriver.php
@@ -72,6 +72,10 @@ class AnnotationDriver implements DriverInterface
 
         foreach ($this->reader->getClassAnnotations($class) as $annot) {
             if ($annot instanceof Service) {
+                if ($annot->decorationInnerName === null && $annot->decoration_inner_name !== null) {
+                    @trigger_error('@Service(decoration_inner_name="...") is deprecated since version 1.8 and will be removed in 2.0. Use @Service(decorationInnerName="...") instead.', E_USER_DEPRECATED);
+                }
+                
                 if (null === $annot->id) {
                     $metadata->id = $this->namingStrategy->classToServiceName($className);
                 } else {
@@ -84,7 +88,7 @@ class AnnotationDriver implements DriverInterface
                 $metadata->shared = $annot->shared;
                 $metadata->abstract = $annot->abstract;
                 $metadata->decorates = $annot->decorates;
-                $metadata->decoration_inner_name = $annot->decoration_inner_name;
+                $metadata->decorationInnerName = $annot->decorationInnerName ?: $annot->decoration_inner_name;
                 $metadata->deprecated = $annot->deprecated;
                 $metadata->environments = $annot->environments;
                 $metadata->autowire = $annot->autowire;

--- a/Metadata/MetadataConverter.php
+++ b/Metadata/MetadataConverter.php
@@ -80,11 +80,15 @@ class MetadataConverter
             $definition->setProperties($classMetadata->properties);
 
             if (null !== $classMetadata->decorates) {
+                if ($classMetadata->decorationInnerName === null && $classMetadata->decoration_inner_name !== null) {
+                    @trigger_error('ClassMetaData::$decoration_inner_name is deprecated since version 1.8 and will be removed in 2.0. Use ClassMetaData::$decorationInnerName instead.', E_USER_DEPRECATED);
+                }
+
                 if (!method_exists($definition, 'setDecoratedService')) {
                     throw new InvalidAnnotationException(sprintf('You must use symfony 2.8 or higher to use decorations on the class %s.', $classMetadata->name));
                 }
 
-                $definition->setDecoratedService($classMetadata->decorates, $classMetadata->decoration_inner_name);
+                $definition->setDecoratedService($classMetadata->decorates, $classMetadata->decorationInnerName !== null ? $classMetadata->decorationInnerName : $classMetadata->decoration_inner_ame);
             }
 
             if (null !== $classMetadata->deprecated && method_exists($definition, 'setDeprecated')) {

--- a/Tests/Metadata/Driver/AnnotationDriverTest.php
+++ b/Tests/Metadata/Driver/AnnotationDriverTest.php
@@ -43,7 +43,7 @@ class AnnotationDriverTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('test.service', $metadata->id);
         $this->assertEquals(array('dev', 'test'), $metadata->environments);
         $this->assertEquals('test.service', $metadata->decorates);
-        $this->assertEquals('original.test.service', $metadata->decoration_inner_name);
+        $this->assertEquals('original.test.service', $metadata->decorationInnerName);
         $this->assertEquals('use new.test.service instead', $metadata->deprecated);
         $this->assertEquals(false, $metadata->public);
         $this->assertEquals(array('JMS\DiExtraBundle\Tests\Metadata\Driver\Fixture\Service'), $metadata->autowiringTypes);

--- a/Tests/Metadata/Driver/Fixture/Service.php
+++ b/Tests/Metadata/Driver/Fixture/Service.php
@@ -9,7 +9,7 @@ use JMS\DiExtraBundle\Annotation as DI; // Use this alias in order to not have t
  *     id="test.service",
  *     environments={"dev", "test"},
  *     decorates="test.service",
- *     decoration_inner_name="original.test.service",
+ *     decorationInnerName="original.test.service",
  *     deprecated="use new.test.service instead",
  *     public=false,
  *     autowire=false,


### PR DESCRIPTION
@Ener-Getick Here is the follow up to #254.

This deprecates `decoration_inner_name` in favor of `decorationInnerName` in both `Service` and `ClassMetadata`.

The point is to offer a consistent naming convention. It's a detail, but I still think it's better to do without it.

All tests are :green_heart:!