### PR TITLE
Fix concurrency issue when warming up the cache

### DIFF
--- a/DependencyInjection/JMSDiExtraExtension.php
+++ b/DependencyInjection/JMSDiExtraExtension.php
@@ -160,11 +160,11 @@ class JMSDiExtraExtension extends Extension
                 $fs->remove($cacheDir);
             }
 
-            if (!file_exists($cacheDir)) {
-                if (false === @mkdir($cacheDir, 0777, true)) {
-                    throw new RuntimeException(sprintf('The cache dir "%s" could not be created.', $cacheDir));
-                }
+            // re-check dir existence to avoid concurrency issues
+            if (!file_exists($cacheDir) && !@mkdir($cacheDir, 0777, true) && !is_dir($cacheDir)) {
+                throw new RuntimeException(sprintf('The cache dir "%s" could not be created.', $cacheDir));
             }
+
             if (!is_writable($cacheDir)) {
                 throw new RuntimeException(sprintf('The cache dir "%s" is not writable.', $cacheDir));
             }


### PR DESCRIPTION
As suggested by PHPStorm's Php Inspections (EA Extended) plugin, the previous if condition creates a race condition:

> This issue is difficult to reproduce, as any of concurrency-related issues. It appears when several processes are attempting to create a directory which is not yet existing, but between is_dir() and mkdir() calls another process already managed to create a directory.

This issue is causing fake failed builds in my project, because I'm launching multiple tests in parallel using https://github.com/facile-it/paraunit