### PR TITLE
Disable xDebug if not needed in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ matrix:
           env: SYMFONY_VERSION=3.0.*
 
 before_script:
+    - if [ "$COVERAGE" != "true" ] && [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then phpenv config-rm xdebug.ini; fi
     - composer self-update
     - if [ "$SYMFONY_VERSION" != "" ]; then composer require --dev --no-update symfony/symfony=$SYMFONY_VERSION; fi
     - composer update $COMPOSER_FLAGS --prefer-source


### PR DESCRIPTION
The last 5 builds of the master branch are failing in PHP 5.3 due to allowed memory exhausted: https://travis-ci.org/schmittjoh/JMSDiExtraBundle/builds/158722091

This disables xDebug where not needed (aka for the coverage) so it should lead to green and faster builds.