### PR TITLE
Fixed ServiceFilesResource pattern finder

### DIFF
--- a/Config/ServiceFilesResource.php
+++ b/Config/ServiceFilesResource.php
@@ -27,17 +27,19 @@ class ServiceFilesResource extends InternalResource
     private $files;
     private $dirs;
     private $disableGrep;
+    private $pattern;
 
-    public function __construct(array $files, array $dirs, $disableGrep)
+    public function __construct(array $files, array $dirs, $disableGrep, $pattern = 'JMS\DiExtraBundle\Annotation')
     {
         $this->files = $files;
         $this->dirs = $dirs;
         $this->disableGrep = $disableGrep;
+        $this->pattern = $pattern;
     }
 
     public function isFresh($timestamp)
     {
-        $finder = new PatternFinder('JMS\DiExtraBundle\Annotation', '*.php', $this->disableGrep);
+        $finder = new PatternFinder($this->pattern, '*.php', $this->disableGrep);
         $files = $finder->findFiles($this->dirs);
 
         return !array_diff($files, $this->files) && !array_diff($this->files, $files);

--- a/DependencyInjection/Compiler/AnnotationConfigurationPass.php
+++ b/DependencyInjection/Compiler/AnnotationConfigurationPass.php
@@ -89,7 +89,7 @@ class AnnotationConfigurationPass implements CompilerPassInterface
     {
         $finder = new PatternFinder($pattern, '*.php', $disableGrep);
         $files = $finder->findFiles($directories);
-        $container->addResource(new ServiceFilesResource($files, $directories, $disableGrep));
+        $container->addResource(new ServiceFilesResource($files, $directories, $disableGrep, $pattern));
         foreach ($files as $file) {
             $container->addResource(new FileResource($file));
             require_once $file;


### PR DESCRIPTION
When using custom service annotations, the `ServiceFilesResource` always shows service files as not fresh, because it looks for the wrong annotation pattern. This causes serious slowdowns in dev mode. See the comments from https://github.com/sonata-project/SonataAdminBundle/issues/4292#issuecomment-276394217