### PR TITLE
Fix compiler deprecated addLogMessage method usage

### DIFF
--- a/DependencyInjection/Compiler/AnnotationConfigurationPass.php
+++ b/DependencyInjection/Compiler/AnnotationConfigurationPass.php
@@ -50,7 +50,7 @@ class AnnotationConfigurationPass implements CompilerPassInterface
 
         $directories = $this->getScanDirectories($container);
         if (!$directories) {
-            $container->getCompiler()->addLogMessage('No directories configured for AnnotationConfigurationPass.');
+            $container->getCompiler()->log($this, 'No directories configured for AnnotationConfigurationPass.');
 
             return;
         }

--- a/DependencyInjection/Compiler/AnnotationConfigurationPass.php
+++ b/DependencyInjection/Compiler/AnnotationConfigurationPass.php
@@ -50,7 +50,11 @@ class AnnotationConfigurationPass implements CompilerPassInterface
 
         $directories = $this->getScanDirectories($container);
         if (!$directories) {
-            $container->getCompiler()->log($this, 'No directories configured for AnnotationConfigurationPass.');
+            if (method_exists($container, 'log')) {
+                $container->log($this, 'No directories configured for AnnotationConfigurationPass.');
+            } else {
+                $container->getCompiler()->addLogMessage('No directories configured for AnnotationConfigurationPass.');
+            }
 
             return;
         }


### PR DESCRIPTION
Since 3.3, addLogMessage method is deprecated and the current message causes an error when trying to parse compiler logs.