### PR TITLE
addClassesToCompile is deprecated since symfony/http-kernel 3.3

### DIFF
--- a/DependencyInjection/JMSDiExtraExtension.php
+++ b/DependencyInjection/JMSDiExtraExtension.php
@@ -71,9 +71,11 @@ class JMSDiExtraExtension extends Extension
             $this->generateEntityManagerProxyClass($config, $container);
         }
 
-        $this->addClassesToCompile(array(
-            'JMS\\DiExtraBundle\\HttpKernel\ControllerResolver',
-        ));
+        if (PHP_VERSION_ID < 70000) {
+            $this->addClassesToCompile(array(
+                'JMS\\DiExtraBundle\\HttpKernel\ControllerResolver',
+            ));
+        }
     }
 
     public function blackListControllerFile($filename)


### PR DESCRIPTION
https://github.com/symfony/symfony/blob/master/UPGRADE-3.3.md#httpkernel
`\Symfony\Component\DependencyInjection\Extension\Extension::addClassesToCompile()` is deprecated since symfony/http-kernel version 3.3
Use only addClassesToCompile with PHP < 7