### PR TITLE
Improve Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
 language: php
+dist: trusty
 
 php:
   - 5.5
   - 5.6
   - 7.0
+  - 7.1
+  - 7.2
   - hhvm
 
 branches:
@@ -38,7 +41,7 @@ before_script:
     - if [ "$COVERAGE" != "true" ] && [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then phpenv config-rm xdebug.ini; fi
     - composer self-update
     - if [ "$SYMFONY_VERSION" != "" ]; then composer require --dev --no-update symfony/symfony=$SYMFONY_VERSION; fi
-    - composer update $COMPOSER_FLAGS --prefer-source
+    - composer update $COMPOSER_FLAGS --prefer-dist --no-interaction
 
 script: if [ "$COVERAGE" == "true" ]; then ./phpunit --coverage-clover=clover; else ./phpunit; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ before_script:
     - if [ "$SYMFONY_VERSION" != "" ]; then composer require --dev --no-update symfony/symfony=$SYMFONY_VERSION; fi
     - composer update $COMPOSER_FLAGS --prefer-dist --no-interaction
 
-script: if [ "$COVERAGE" == "true" ]; then ./phpunit --coverage-clover=clover; else ./phpunit; fi
+script: if [ "$COVERAGE" == "true" ]; then ./phpunit --coverage-clover=clover; else ./phpunit --debug; fi
 
 after_success:
     - if [ "$COVERAGE" == "true" ]; then curl -sL https://bit.ly/artifact-uploader | php; fi

--- a/Tests/DependencyInjection/Collection/LazyServiceMapTest.php
+++ b/Tests/DependencyInjection/Collection/LazyServiceMapTest.php
@@ -19,10 +19,11 @@
 namespace JMS\DiExtraBundle\Tests\DependencyInjection\Collection;
 
 use JMS\DiExtraBundle\DependencyInjection\Collection\LazyServiceMap;
+use PHPUnit\Framework\TestCase;
 use PHPUnit_Framework_MockObject_MockObject;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
-class LazyServiceMapTest extends \PHPUnit_Framework_TestCase
+class LazyServiceMapTest extends TestCase
 {
     /**
      * @var LazyServiceMap

--- a/Tests/DependencyInjection/Collection/LazyServiceSequenceTest.php
+++ b/Tests/DependencyInjection/Collection/LazyServiceSequenceTest.php
@@ -19,8 +19,9 @@
 namespace JMS\DiExtraBundle\Tests\DependencyInjection\Collection;
 
 use JMS\DiExtraBundle\DependencyInjection\Collection\LazyServiceSequence;
+use PHPUnit\Framework\TestCase;
 
-class LazyServiceSequenceTest extends \PHPUnit_Framework_TestCase
+class LazyServiceSequenceTest extends TestCase
 {
     private $container;
     private $seq;

--- a/Tests/DependencyInjection/Compiler/AnnotationConfigurationPassTest.php
+++ b/Tests/DependencyInjection/Compiler/AnnotationConfigurationPassTest.php
@@ -21,12 +21,13 @@ namespace JMS\DiExtraBundle\Tests\DependencyInjection\Compiler;
 use Doctrine\Common\Annotations\AnnotationReader;
 use JMS\DiExtraBundle\DependencyInjection\Compiler\AnnotationConfigurationPass;
 use JMS\DiExtraBundle\DependencyInjection\JMSDiExtraExtension;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\DefinitionDecorator;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\Filesystem\Filesystem;
 
-class AnnotationConfigurationPassTest extends \PHPUnit_Framework_TestCase
+class AnnotationConfigurationPassTest extends TestCase
 {
     public function testProcess()
     {

--- a/Tests/DependencyInjection/Compiler/LazyServiceMapPassTest.php
+++ b/Tests/DependencyInjection/Compiler/LazyServiceMapPassTest.php
@@ -19,11 +19,12 @@
 namespace JMS\DiExtraBundle\Tests\DependencyInjection\Compiler;
 
 use JMS\DiExtraBundle\DependencyInjection\Compiler\LazyServiceMapPass;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
 
-class LazyServiceMapPassTest extends \PHPUnit_Framework_TestCase
+class LazyServiceMapPassTest extends TestCase
 {
     public function testProcess()
     {

--- a/Tests/DependencyInjection/Compiler/LazyServiceSequencePassTest.php
+++ b/Tests/DependencyInjection/Compiler/LazyServiceSequencePassTest.php
@@ -19,11 +19,12 @@
 namespace JMS\DiExtraBundle\Tests\DependencyInjection\Compiler;
 
 use JMS\DiExtraBundle\DependencyInjection\Compiler\LazyServiceSequencePass;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
 
-class LazyServiceSequencePassTest extends \PHPUnit_Framework_TestCase
+class LazyServiceSequencePassTest extends TestCase
 {
     public function testProcess()
     {

--- a/Tests/DependencyInjection/Compiler/ResourceOptimizationPassTest.php
+++ b/Tests/DependencyInjection/Compiler/ResourceOptimizationPassTest.php
@@ -19,10 +19,11 @@
 namespace JMS\DiExtraBundle\Tests\DependencyInjection\Compiler;
 
 use JMS\DiExtraBundle\DependencyInjection\Compiler\ResourceOptimizationPass;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\Resource\DirectoryResource;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
-class ResourceOptimizationPassTest extends \PHPUnit_Framework_TestCase
+class ResourceOptimizationPassTest extends TestCase
 {
     public function testProcess()
     {

--- a/Tests/Finder/AbstractPatternFinderTest.php
+++ b/Tests/Finder/AbstractPatternFinderTest.php
@@ -18,7 +18,9 @@
 
 namespace JMS\DiExtraBundle\Tests\Finder;
 
-abstract class AbstractPatternFinderTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+abstract class AbstractPatternFinderTest extends TestCase
 {
     public function testFindFiles()
     {

--- a/Tests/Metadata/ClassMetadataTest.php
+++ b/Tests/Metadata/ClassMetadataTest.php
@@ -19,8 +19,9 @@
 namespace JMS\DiExtraBundle\Tests\Metadata;
 
 use JMS\DiExtraBundle\Metadata\ClassMetadata;
+use PHPUnit\Framework\TestCase;
 
-class ClassMetadataTest extends \PHPUnit_Framework_TestCase
+class ClassMetadataTest extends TestCase
 {
     public function testSerializeUnserialize()
     {

--- a/Tests/Metadata/Driver/AnnotationDriverTest.php
+++ b/Tests/Metadata/Driver/AnnotationDriverTest.php
@@ -21,8 +21,9 @@ namespace JMS\DiExtraBundle\Tests\Metadata\Driver;
 use Doctrine\Common\Annotations\AnnotationReader;
 use JMS\DiExtraBundle\Metadata\DefaultNamingStrategy;
 use JMS\DiExtraBundle\Metadata\Driver\AnnotationDriver;
+use PHPUnit\Framework\TestCase;
 
-class AnnotationDriverTest extends \PHPUnit_Framework_TestCase
+class AnnotationDriverTest extends TestCase
 {
     public function testFormType()
     {

--- a/Tests/Metadata/Driver/ConfiguredControllerInjectionsDriverTest.php
+++ b/Tests/Metadata/Driver/ConfiguredControllerInjectionsDriverTest.php
@@ -20,9 +20,10 @@ namespace JMS\DiExtraBundle\Tests\Metadata\Driver;
 
 use JMS\DiExtraBundle\Metadata\ClassMetadata;
 use JMS\DiExtraBundle\Metadata\Driver\ConfiguredControllerInjectionsDriver;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Reference;
 
-class ConfiguredControllerInjectionsDriverTest extends \PHPUnit_Framework_TestCase
+class ConfiguredControllerInjectionsDriverTest extends TestCase
 {
     public function testIgnoresNonControllers()
     {

--- a/Tests/PerformanceTest.php
+++ b/Tests/PerformanceTest.php
@@ -20,6 +20,7 @@ namespace JMS\DiExtraBundle\Tests;
 
 use JMS\DiExtraBundle\Finder\ServiceFinder;
 use JMS\SecurityExtraBundle\JMSSecurityExtraBundle;
+use PHPUnit\Framework\TestCase;
 use Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle;
 use Symfony\Bundle\AsseticBundle\AsseticBundle;
 use Symfony\Bundle\DoctrineBundle\DoctrineBundle;
@@ -31,7 +32,7 @@ use Symfony\Bundle\TwigBundle\TwigBundle;
 /**
  * @group performance
  */
-class PerformanceTest extends \PHPUnit_Framework_TestCase
+class PerformanceTest extends TestCase
 {
     /**
      * @dataProvider getFinderMethods

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "doctrine/orm": "~2.3",
         "phpcollection/phpcollection": ">=0.2,<0.3-dev",
         "symfony/phpunit-bridge": "~3.2",
-        "phpunit/phpunit": "^5.0.0"
+        "phpunit/phpunit": "^4.8.35|^5.4.4"
     },
     "autoload": {
         "psr-4": { "JMS\\DiExtraBundle\\": "" }


### PR DESCRIPTION
The current build on master is failing for multiple reasons. This is to do multiple stuff:
 - allow PHPUnit 4 to avoid failures on PHP <5.6
 - migrate to namespaced PHPUnit classes for FC
 - fix HHVM build
 - Add PHP 7.1 and 7.2 to build matrix