### PR TITLE
Fix controller injections when there are no dirs to scan

### DIFF
--- a/HttpKernel/ControllerInjectorsWarmer.php
+++ b/HttpKernel/ControllerInjectorsWarmer.php
@@ -83,10 +83,15 @@ class ControllerInjectorsWarmer implements CacheWarmerInterface
             $dirs[] = $controllerDir;
         }
 
-        foreach (Finder::create()->name('*Controller.php')->in($dirs)->files() as $file) {
-            $filename = $file->getRealPath();
-            if (!in_array($filename, $this->blackListedControllerFiles)) {
-                require_once $filename;
+        // Combination of scanAllBundles/scanBundles can lead to empty dirs.
+        // Only search for controllers if we have at least one directory,
+        // otherwise the finder will throw an exception.
+        if (!empty($dirs)) {
+            foreach (Finder::create()->name('*Controller.php')->in($dirs)->files() as $file) {
+                $filename = $file->getRealPath();
+                if (!in_array($filename, $this->blackListedControllerFiles)) {
+                    require_once $filename;
+                }
             }
         }
 


### PR DESCRIPTION
This should solve https://github.com/schmittjoh/JMSDiExtraBundle/issues/287.

With empty configuration or when the combination of `all_bundles` and `bundles` [options](http://jmsyst.com/bundles/JMSDiExtraBundle/master/configuration) led up to empty folders in controller injector warmer, the finder component throws an exception.

Offending commit https://github.com/schmittjoh/JMSDiExtraBundle/commit/55c3f875f08a333848284cdbc1fd3e0cea4e6776