### PR TITLE
Issue#282: call setContainer on ContainerAwareInterface

### DIFF
--- a/HttpKernel/ControllerResolver.php
+++ b/HttpKernel/ControllerResolver.php
@@ -75,12 +75,16 @@ class ControllerResolver extends BaseControllerResolver
      */
     protected function instantiateController($class)
     {
+        $controller = null;
+
         if ($this->container->has($class)) {
-            return $this->container->get($class);
+            $controller = $this->container->get($class);
         }
 
-        $injector = $this->createInjector($class);
-        $controller = call_user_func($injector, $this->container);
+        if (null === $controller) {
+            $injector = $this->createInjector($class);
+            $controller = call_user_func($injector, $this->container);
+        }
 
         if ($controller instanceof ContainerAwareInterface) {
             $controller->setContainer($this->container);

--- a/Tests/Functional/AutowiredControllerTest.php
+++ b/Tests/Functional/AutowiredControllerTest.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * Copyright 2011 Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace JMS\DiExtraBundle\Tests\Functional;
+
+class AutowiredControllerTest extends BaseTestCase
+{
+    /**
+     * @runInSeparateProcess
+     */
+    public function testAutowiredController()
+    {
+        $client = $this->createClient(array(
+            'config' => 'autowired_controller.yml',
+        ));
+        $client->request('GET', '/autowired-controller-test');
+
+        $expected = '';
+        $expected .= "\$has container: OK\n";
+
+
+        $this->assertEquals($expected, $client->getResponse()->getContent());
+    }
+}

--- a/Tests/Functional/AutowiredControllerTest.php
+++ b/Tests/Functional/AutowiredControllerTest.php
@@ -25,14 +25,11 @@ class AutowiredControllerTest extends BaseTestCase
      */
     public function testAutowiredController()
     {
-        $client = $this->createClient(array(
-            'config' => 'autowired_controller.yml',
-        ));
+        $client = $this->createClient();
         $client->request('GET', '/autowired-controller-test');
 
         $expected = '';
         $expected .= "\$has container: OK\n";
-
 
         $this->assertEquals($expected, $client->getResponse()->getContent());
     }

--- a/Tests/Functional/Bundle/LegacyTestBundle/Controller/AutowiredController.php
+++ b/Tests/Functional/Bundle/LegacyTestBundle/Controller/AutowiredController.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * Copyright 2011 Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace JMS\DiExtraBundle\Tests\Functional\Bundle\LegacyTestBundle\Controller;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Response;
+
+class AutowiredController extends Controller
+{
+    /**
+     * @Route("/autowired-controller-test")
+     */
+    public function testAction()
+    {
+        $content = '';
+        $content .= sprintf("\$has container: %s\n", $this->container !== null ? 'OK' : 'FAILED');
+
+        return new Response($content);
+    }
+}

--- a/Tests/Functional/Bundle/TestBundle/Controller/AutowiredController.php
+++ b/Tests/Functional/Bundle/TestBundle/Controller/AutowiredController.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * Copyright 2011 Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace JMS\DiExtraBundle\Tests\Functional\Bundle\TestBundle\Controller;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Response;
+
+class AutowiredController extends Controller
+{
+    /**
+     * @Route("/autowired-controller-test")
+     */
+    public function testAction()
+    {
+        $content = '';
+        $content .= sprintf("\$has container: %s\n", $this->container !== null ? 'OK' : 'FAILED');
+
+        return new Response($content);
+    }
+}

--- a/Tests/Functional/config/autowired_controller.yml
+++ b/Tests/Functional/config/autowired_controller.yml
@@ -1,8 +1,0 @@
-imports:
-    - { resource: default.yml }
-
-services:
-    autowired_controller:
-        class: JMS\DiExtraBundle\Tests\Functional\Bundle\TestBundle\Controller\AutowiredController
-        autowired: true
-

--- a/Tests/Functional/config/autowired_controller.yml
+++ b/Tests/Functional/config/autowired_controller.yml
@@ -1,0 +1,8 @@
+imports:
+    - { resource: default.yml }
+
+services:
+    autowired_controller:
+        class: JMS\DiExtraBundle\Tests\Functional\Bundle\TestBundle\Controller\AutowiredController
+        autowired: true
+

--- a/Tests/Functional/config/default.yml
+++ b/Tests/Functional/config/default.yml
@@ -13,6 +13,9 @@ services:
     controller.hello:
         class: JMS\DiExtraBundle\Tests\Functional\Bundle\TestBundle\Controller\ServiceController
         arguments: [ "@router" ]
+    controller.autowired:
+        class: JMS\DiExtraBundle\Tests\Functional\Bundle\TestBundle\Controller\AutowiredController
+        autowired: true
 
 sensio_framework_extra:
     request: { converters: false }


### PR DESCRIPTION
Autowired controllers break when not calling setContainer on
ContainerAwareInterface implementations.