### PR TITLE
Solves #298

### DIFF
--- a/DependencyInjection/Compiler/IntegrationPass.php
+++ b/DependencyInjection/Compiler/IntegrationPass.php
@@ -66,7 +66,7 @@ class IntegrationPass implements CompilerPassInterface
             }
 
             $public = $definition->isPublic();
-            $private = $definition->isPrivate();
+            $private = \method_exists($definition,'isPrivate') ? $definition->isPrivate() : false;
 
             $definition->setPublic(false);
             $container->setDefinition($id.'.delegate', $definition);

--- a/DependencyInjection/Compiler/IntegrationPass.php
+++ b/DependencyInjection/Compiler/IntegrationPass.php
@@ -66,16 +66,21 @@ class IntegrationPass implements CompilerPassInterface
             }
 
             $public = $definition->isPublic();
-            $private = \method_exists($definition,'isPrivate') ? $definition->isPrivate() : false;
-
             $definition->setPublic(false);
+            
             $container->setDefinition($id.'.delegate', $definition);
-            $container->register($id, $container->getParameter('jms_di_extra.doctrine_integration.entity_manager.class'))
+            
+            $newDefinition = $container->register($id, $container->getParameter('jms_di_extra.doctrine_integration.entity_manager.class'))
                 ->setFile($container->getParameter('jms_di_extra.doctrine_integration.entity_manager.file'))
                 ->addArgument(new Reference($id.'.delegate'))
-                ->addArgument(new Reference('service_container'))
-                ->setPrivate($private)
-                ->setPublic($public);
+                ->addArgument(new Reference('service_container'));
+            
+            if (\method_exists($newDefinition, 'isPrivate')) {
+                $newDefinition->setPrivate($definition->isPrivate())
+                    ->setPublic($public);
+            } else {
+                $newDefinition->setPublic($public);
+            }
         }
     }
 }

--- a/DependencyInjection/Compiler/IntegrationPass.php
+++ b/DependencyInjection/Compiler/IntegrationPass.php
@@ -70,17 +70,11 @@ class IntegrationPass implements CompilerPassInterface
             
             $container->setDefinition($id.'.delegate', $definition);
             
-            $newDefinition = $container->register($id, $container->getParameter('jms_di_extra.doctrine_integration.entity_manager.class'))
+            $container->register($id, $container->getParameter('jms_di_extra.doctrine_integration.entity_manager.class'))
                 ->setFile($container->getParameter('jms_di_extra.doctrine_integration.entity_manager.file'))
                 ->addArgument(new Reference($id.'.delegate'))
-                ->addArgument(new Reference('service_container'));
-            
-            if (\method_exists($newDefinition, 'isPrivate')) {
-                $newDefinition->setPrivate($definition->isPrivate())
-                    ->setPublic($public);
-            } else {
-                $newDefinition->setPublic($public);
-            }
+                ->addArgument(new Reference('service_container'))
+                ->setPublic($public);
         }
     }
 }

--- a/DependencyInjection/Compiler/IntegrationPass.php
+++ b/DependencyInjection/Compiler/IntegrationPass.php
@@ -65,12 +65,17 @@ class IntegrationPass implements CompilerPassInterface
                 continue;
             }
 
+            $public = $definition->isPublic();
+            $private = $definition->isPrivate();
+
             $definition->setPublic(false);
             $container->setDefinition($id.'.delegate', $definition);
             $container->register($id, $container->getParameter('jms_di_extra.doctrine_integration.entity_manager.class'))
                 ->setFile($container->getParameter('jms_di_extra.doctrine_integration.entity_manager.file'))
                 ->addArgument(new Reference($id.'.delegate'))
-                ->addArgument(new Reference('service_container'));
+                ->addArgument(new Reference('service_container'))
+                ->setPrivate($private)
+                ->setPublic($public);
         }
     }
 }


### PR DESCRIPTION
Solves:

User Deprecated: The "doctrine.orm.default_entity_manager" service is private, getting it from the container is deprecated since Symfony 3.2 and will fail in 4.0. You should either make the service public, or stop using the container directly and use dependency injection instead.

This warning is caused by the JMSDIExtraBundle proxy replacing the Doctrine Service.
JMSDIExtraBundle, does not properly preserve the service visibility when overwriting the service.